### PR TITLE
Blog edits & add twitter link to Community section

### DIFF
--- a/blog/2023-02-21-introducing-rollkit.mdx
+++ b/blog/2023-02-21-introducing-rollkit.mdx
@@ -18,10 +18,9 @@ In development since 2021, Rollkit is now emerging as neutral and independent fr
 
 ## Tl;dr:
 
-- You can now [build with Rollkit](/) on Celestia’s Mocha testnet. Check out the [docs](/docs/intro).
-- You can customize rollups and plug in arbitrary data availability and execution layers by leveraging Rollkit’s modular framework.
-- Rollkit is spinning out from Celestia so that both can serve the modular ecosystem as credibly neutral public goods.
-- Stay tuned for Rollkit developer calls that begin in April to help guide its development.
+- You can now [build with Rollkit](/) on Celestia’s Mocha testnet. Check out the [docs](/)
+- You can customize rollups and plug-in arbitrary data availability and execution layers by leveraging Rollkit’s modular framework
+- Join our Rollkit developer calls that begin in April to help guide its development
 
 ## Deploying a new chain is hard
 
@@ -47,7 +46,7 @@ In the spirit of modularity, Rollkit’s long-term vision is to give developers 
 
 In a rapidly evolving industry like blockchain, time to market and the ability to rapidly experiment and innovate are critical. Rollkit’s customizable stack will enable developers to bring their products to market faster and with more flexibility.
 
-![Rollkit lego](../static/img/introducing-rollkit/rollkit-lego.png)
+![Rollkit lego image](../static/img/introducing-rollkit/rollkit-lego.png)
 
 ### Execution environments
 
@@ -65,9 +64,9 @@ Rollkit will support a multitude of proof schemes to ensure the execution of you
 
 Rollkit will allow you to build a diverse range of rollups, including sovereign rollups, settlement rollups and settled rollups.
 
-Rollkit is in an early stage of development and many features remain to be built to reach this vision. In its [current state](/docs/rollkit-stack), Rollkit rollups are [sovereign rollups](https://blog.celestia.org/sovereign-rollup-chains) with single sequencers, with support for a pessimistic mode and a [work-in-progress optimistic](https://github.com/rollkit/rollkit/blob/manav/state_fraud_proofs_adr/docs/lazy-adr/adr-009-state-fraud-proofs.md) mode. [Integration tutorials](/docs/category/tutorials) are ready and available with Cosmos SDK, Ethermint, and CosmWasm.
+Rollkit is in an early stage of development and many features remain to be built to reach this vision. In its [current state](/docs/rollkit-stack), Rollkit rollups are [sovereign rollups](https://blog.celestia.org/sovereign-rollup-chains) with single sequencers, with support for a pessimistic mode and a [work-in-progress optimistic mode](https://github.com/rollkit/rollkit/blob/manav/state_fraud_proofs_adr/docs/lazy-adr/adr-009-state-fraud-proofs.md). [Integration tutorials](/docs/category/tutorials) are ready and available with Cosmos SDK, Ethermint, and CosmWasm.
 
-We invite the community to collaborate with us to build new features. Each new team that joins the growing Rollkit community brings more firepower to ship new features that we all benefit from. This is the power of modularity in action.
+We invite the community to collaborate with us to build new features. Each new team that joins the growing Rollkit community brings more firepower to ship new features that we all benefit from. This is the power of modularity in action. 
 
 ## Rollkit is neutral
 
@@ -87,7 +86,7 @@ We believe that to create a positive-sum crypto ecosystem where modularism thriv
 
 ## Next steps
 
-Moving towards a community-led project means increased visibility, transparency and inclusivity. That’s why the Rollkit team will soon release a roadmap blog post to detail ongoing work and its purpose. The team will also hold regular public calls with community members to showcase recent developments, discuss the roadmap and gather feedback from developers building with Rollkit. Keep an eye out for a new announcement from Rollkit.
+Moving towards a community-led project means increased visibility, transparency and inclusivity. That’s why the Rollkit team will soon release a roadmap blog post to detail ongoing work and its purpose. The team will also hold regular public calls with community members to showcase recent developments, discuss the roadmap and gather feedback from developers building with Rollkit. Keep an eye out for a new announcement from Rollkit. 
 
 Learn more about how Rollkit works [on the new Rollkit website](/) (you're already on it!). And don’t forget to check out the [Rollkit repo](https://github.com/rollkit) too.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -121,6 +121,10 @@ const config = {
                 label: 'Telegram',
                 href: 'https://t.me/rollkit'
               },
+              {
+                label: 'Twitter',
+                href: 'https://twitter.com/Rollkitdev'
+              },
             ],
           },
           {


### PR DESCRIPTION
This PR adds a link to Twitter in the Community section. It also resolves discrepancies between the original blog post and the duplicate version on this site.

Regarding the link to Twitter: as a developer interested in building, or someone interested in following along or contributing in another manner, how would I follow for updates? check the site for updates? no. I am adding the link to the Twitter in this PR so that there is a place for non-devs (people who want to follow the project, generally) to engage, even if it's just following an account with no tweets yet
