### PR TITLE
Update gm-world.md

### DIFF
--- a/docs/tutorials/gm-world.md
+++ b/docs/tutorials/gm-world.md
@@ -293,7 +293,7 @@ Download the `init.sh` script to start the chain:
 
 ```bash
 # From inside the `gm` directory
-wget https://raw.githubusercontent.com/rollkit/docs/main/docs/scripts/gm/init-local.sh
+wget https://github.com/rollkit/docs/blob/main/docs/scripts/gm/init-local.sh
 ```
 
 Run the `init-local.sh` script:


### PR DESCRIPTION
The link provided before the edits is unreachable and hence the codes aren't working.

The problem faced is pasted below :
wget https://raw.githubusercontent.com/rollkit/docs/main/docs/scripts/gm
/init-local.sh
--2023-05-25 23:16:45--  https://raw.githubusercontent.com/rollkit/docs/main/docs/scripts/gm/init-local.sh
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 2405:200:1607:2820:41::36, 49.44.79.236
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|2405:200:1607:2820:41::36|:443... failed: Connection timed out.
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|49.44.79.236|:443... failed: Connection timed out.
Retrying.

--2023-05-25 23:21:07--  (try: 2)  https://raw.githubusercontent.com/rollkit/docs/main/docs/scripts/gm/init-local.sh
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|2405:200:1607:2820:41::36|:443... failed: Connection timed out.
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|49.44.79.236|:443... failed: Connection timed out.
Retrying.

--2023-05-25 23:25:30--  (try: 3)  https://raw.githubusercontent.com/rollkit/docs/main/docs/scripts/gm/init-local.sh
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|2405:200:1607:2820:41::36|:443... failed: Connection timed out.
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|49.44.79.236|:443... failed: Connection timed out.
Retrying.

--2023-05-25 23:29:56--  (try: 4)  https://raw.githubusercontent.com/rollkit/docs/main/docs/scripts/gm/init-local.sh
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|2405:200:1607:2820:41::36|:443... 