### PR TITLE
set path to title of page to remove "Rollkit | Rollkit" from home page title

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -10,6 +10,7 @@ const { BASE: base = "/" } = process.env;
 export default withMermaid({
   lang: 'en-US',
   title: "Rollkit",
+  titleTemplate: ':title',
   description: "The open modular framework for sovereign rollups.",
   lastUpdated: true,
   cleanUrls: true,


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Resolves #220 

This sets title to `:title` so that the homepage displays like this:

<img width="142" alt="testing 2023-08-15 at 11 00 21" src="https://github.com/rollkit/docs/assets/46639943/24117b5d-c520-41dd-91b6-61f2c18cb945">

instead of:
<img width="154" alt="testing 2023-08-15 at 11 00 46" src="https://github.com/rollkit/docs/assets/46639943/c263149b-2d73-4518-9dfb-e8f386243e11">

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
