### PR TITLE
docs: fix tip in "gm-world"

### DIFF
--- a/tutorials/gm-world.md
+++ b/tutorials/gm-world.md
@@ -543,7 +543,7 @@ chain history and binary:
 
 ```bash
 rm -rf $HOME/.gm
-rm $HOME/go/bin
+rm $HOME/go/bin/gmd
 ```
 
 :::


### PR DESCRIPTION
The current guide recommends users to remove the entire `$HOME/go/bin` directory. I don't think this is ok.

I updated the guide to delete the `gmd` binary instead, as indicated by @jcstein [here](https://github.com/rollkit/docs/issues/224#issuecomment-1682475676).