### PR TITLE
bug: fix rpc address in gm local tutorial

### DIFF
--- a/scripts/gm/init-local.sh
+++ b/scripts/gm/init-local.sh
@@ -81,7 +81,7 @@ gmd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
 gmd collect-gentxs
 
 # start the chain
-gmd start --rollkit.aggregator true --rollkit.da_layer celestia --rollkit.da_config='{"base_url":"http://localhost:26658","timeout":60000000000,"fee":600000,"gas_limit":6000000,"auth_token":"'$AUTH_TOKEN'"}' --rollkit.namespace_id $NAMESPACE_ID --rollkit.da_start_height $DA_BLOCK_HEIGHT
+gmd start --rollkit.aggregator true --rollkit.da_layer celestia --rollkit.da_config='{"base_url":"http://localhost:26658","timeout":60000000000,"fee":600000,"gas_limit":6000000,"auth_token":"'$AUTH_TOKEN'"}' --rollkit.namespace_id $NAMESPACE_ID --rollkit.da_start_height $DA_BLOCK_HEIGHT --rpc.laddr tcp://127.0.0.1:36657
 
 # uncomment the next command if you are using lazy aggregation
-# gmd start --rollkit.aggregator true --rollkit.da_layer celestia --rollkit.da_config='{"base_url":"http://localhost:26658","timeout":60000000000,"fee":600000,"gas_limit":6000000,"auth_token":"'$AUTH_TOKEN'"}' --rollkit.namespace_id $NAMESPACE_ID --rollkit.da_start_height $DA_BLOCK_HEIGHT --rollkit.lazy_aggregator
+# gmd start --rollkit.aggregator true --rollkit.da_layer celestia --rollkit.da_config='{"base_url":"http://localhost:26658","timeout":60000000000,"fee":600000,"gas_limit":6000000,"auth_token":"'$AUTH_TOKEN'"}' --rollkit.namespace_id $NAMESPACE_ID --rollkit.da_start_height $DA_BLOCK_HEIGHT --rpc.laddr tcp://127.0.0.1:36657 --rollkit.lazy_aggregator

--- a/tutorials/gm-world.md
+++ b/tutorials/gm-world.md
@@ -588,8 +588,15 @@ So using our information from the [keys](#keys) command, we can construct the tr
 <!-- markdownlint-enable MD051 -->
 
 ```bash
-gmd tx bank send $KEY1 $KEY2 42069stake --keyring-backend test
+gmd tx bank send $KEY1 $KEY2 42069stake --keyring-backend test \
+--node tcp://127.0.0.1:36657
 ```
+
+::: tip
+We're using the `--node [ip:port]` flag to point to port 36657, which is
+the custom port we used in the `init-local.sh` script to avoid
+clashing with 26657 on local-celestia-devnet.
+:::
 
 You'll be prompted to accept the transaction:
 
@@ -641,7 +648,7 @@ txhash: 677CAF6C80B85ACEF6F9EC7906FB3CB021322AAC78B015FA07D5112F2F824BFF
 Then, query your balance:
 
 ```bash
-gmd query bank balances $KEY2
+gmd query bank balances $KEY2 --node tcp://127.0.0.1:36657
 ```
 
 This is the key that received the balance, so it should have increased past the initial `STAKING_AMOUNT`:
@@ -658,7 +665,7 @@ pagination:
 The other key, should have decreased in balance:
 
 ```bash
-gmd query bank balances $KEY1
+gmd query bank balances $KEY1 --node tcp://127.0.0.1:36657
 ```
 
 Response:
@@ -900,6 +907,16 @@ Before starting the rollup, we need to remove the old project folders:
 
 ```bash
 rm -r $HOME/go/bin/gmd && rm -rf $HOME/.gm
+```
+
+##### Set the auth token for your light node
+
+You will also need to set the auth token for your Celestia light node
+before running the rollup. In the terminal that you will run the
+`init-testnet.sh` script in, run the following:
+
+```bash
+export AUTH_TOKEN=$(celestia light auth admin --p2p.network arabica)
 ```
 
 ##### Start the new chain {#start-the-new-chain}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This fixes an error with clashing ports from local-celestia-devnet and the gm rollup example.

Thank you for reporting the bug @PaulRBerg!

Resolves #233
Resolves #235 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
