### PR TITLE
fix: favicon, light mode version only

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -19,34 +19,7 @@ export default withMermaid({
   head: [
     ['link', { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }],
     ['link', { rel: 'icon', href: '/favicon.png', type: 'image/png' }],
-    [
-      'link',
-      {
-        rel: 'icon',
-        type: 'image/svg+xml',
-        href: '/favicon-dark.svg',
-        media: '(prefers-color-scheme: dark)',
-      },
-    ],
-    [
-      'link',
-      {
-        rel: 'icon',
-        type: 'image/png',
-        href: '/favicon-dark.png',
-        media: '(prefers-color-scheme: dark)',
-      },
-    ],
     ['link', { rel: 'shortcut icon', href: '/favicon.ico', type: 'image/x-icon' }],
-    [
-      'link',
-      {
-        rel: 'icon',
-        type: 'image/x-icon',
-        href: '/favicon-dark.ico',
-        media: '(prefers-color-scheme: dark)',
-      },
-    ],
     ['meta', { name: 'msapplication-TileColor', content: '#fff' }],
     ['meta', { name: 'theme-color', content: '#fff' }],
     ['meta', { name: 'viewport', content: 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no' }],

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -19,7 +19,34 @@ export default withMermaid({
   head: [
     ['link', { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }],
     ['link', { rel: 'icon', href: '/favicon.png', type: 'image/png' }],
+    // [
+    //   'link',
+    //   {
+    //     rel: 'icon',
+    //     type: 'image/svg+xml',
+    //     href: '/favicon-dark.svg',
+    //     media: '(prefers-color-scheme: dark)',
+    //   },
+    // ],
+    // [
+    //   'link',
+    //   {
+    //     rel: 'icon',
+    //     type: 'image/png',
+    //     href: '/favicon-dark.png',
+    //     media: '(prefers-color-scheme: dark)',
+    //   },
+    // ],
     ['link', { rel: 'shortcut icon', href: '/favicon.ico', type: 'image/x-icon' }],
+    // [
+    //   'link',
+    //   {
+    //     rel: 'icon',
+    //     type: 'image/x-icon',
+    //     href: '/favicon-dark.ico',
+    //     media: '(prefers-color-scheme: dark)',
+    //   },
+    // ],
     ['meta', { name: 'msapplication-TileColor', content: '#fff' }],
     ['meta', { name: 'theme-color', content: '#fff' }],
     ['meta', { name: 'viewport', content: 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no' }],


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This resolves #244 with wrong color of favicon being indexed by search engines.

This is likely an issue with the .ico being indexed, and the dark/light mode switch with vitepress would work and not be indexed. but in the case that the .svg/xml/png versions are indexed too, using this to be safe.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
