### PR TITLE
chore: use 8 bytes instead of 10 because rollkit only accounts for 8

### DIFF
--- a/scripts/cosmwasm/init.sh
+++ b/scripts/cosmwasm/init.sh
@@ -10,7 +10,7 @@ CHAINFLAG="--chain-id ${CHAIN_ID}"
 TXFLAG="--chain-id ${CHAIN_ID} --gas-prices 0uwasm --gas auto --gas-adjustment 1.3"
 
 # create a random Namespace ID for your rollup to post blocks to
-NAMESPACE=$(openssl rand -hex 10)
+NAMESPACE=$(openssl rand -hex 8)
 echo $NAMESPACE
 
 # query the DA Layer start height, in this case we are querying

--- a/scripts/gm/init-local.sh
+++ b/scripts/gm/init-local.sh
@@ -10,7 +10,7 @@ TOKEN_AMOUNT="10000000000000000000000000stake"
 STAKING_AMOUNT="1000000000stake"
 
 # create a random Namespace ID for your rollup to post blocks to
-NAMESPACE=$(openssl rand -hex 10)
+NAMESPACE=$(openssl rand -hex 8)
 
 # query the DA Layer start height, in this case we are querying
 # our local devnet at port 26657, the RPC. The RPC endpoint is

--- a/scripts/gm/init-testnet.sh
+++ b/scripts/gm/init-testnet.sh
@@ -10,7 +10,7 @@ TOKEN_AMOUNT="10000000000000000000000000stake"
 STAKING_AMOUNT="1000000000stake"
 
 # create a random Namespace ID for your rollup to post blocks to
-NAMESPACE=$(openssl rand -hex 10)
+NAMESPACE=$(openssl rand -hex 8)
 echo $NAMESPACE
 
 # query the DA Layer start height, in this case we are querying

--- a/scripts/recipes/init.sh
+++ b/scripts/recipes/init.sh
@@ -9,7 +9,7 @@ TOKEN_AMOUNT="10000000000000000000000000stake"
 STAKING_AMOUNT="1000000000stake"
 
 # create a random Namespace ID for your rollup to post blocks to
-NAMESPACE=$(openssl rand -hex 10)
+NAMESPACE=$(openssl rand -hex 8)
 echo $NAMESPACE
 
 # query the DA Layer start height, in this case we are querying

--- a/scripts/wordle/init.sh
+++ b/scripts/wordle/init.sh
@@ -9,7 +9,7 @@ TOKEN_AMOUNT="10000000000000000000000000stake"
 STAKING_AMOUNT="1000000000stake"
 
 # create a random Namespace ID for your rollup to post blocks to
-NAMESPACE=$(openssl rand -hex 10)
+NAMESPACE=$(openssl rand -hex 8)
 echo $NAMESPACE
 
 # query the DA Layer start height, in this case we are querying


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Resolves #276 until rollkit accounts for more than 8 bytes

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized the length of randomly generated `NAMESPACE` identifiers across various initialization scripts from 10 to 8 characters to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->