### PR TITLE
fix: lock Polaris working version

### DIFF
--- a/tutorials/polaris-evm.md
+++ b/tutorials/polaris-evm.md
@@ -38,7 +38,7 @@ To get started, clone the Polaris repository and switch to the Rollkit branch:
 ```bash
 cd $HOME
 git clone https://github.com/berachain/polaris.git
-cd polaris && git checkout rollkit-main
+cd polaris && git checkout rollkit-stable
 ```
 
 ## Install Foundry
@@ -248,7 +248,7 @@ celestia light start --core.ip rpc-mocha.pops.one --p2p.network mocha
 First, ensure you're on the correct branch of Polaris:
 
 ```bash
-cd $HOME/polaris && git checkout rollkit-main
+cd $HOME/polaris && git checkout rollkit-stable
 ```
 
 Before starting your rollup, you'll want to make changes in `$HOME/polaris/e2e/testapp/entrypoint.sh`.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The current version of `rollkit-main` is not stable.

1. When updating to use centralized sequencer on `rollkit-main` at https://github.com/berachain/polaris/commit/718758380be80614c8f977333fbe9f5fb4efebad, [i see a an error](https://app.warp.dev/block/huk7m5B85luUm3QkJnlNby):

```bash
9:31AM ERR failure when running app err="error while initializing BlockManager: must have exactly 1 validator (the centralized sequencer)"
make: *** [start] Error 1
```

To fix this, I have made a new branch based on the last working commit of `rollkit-main`, called `rollkit-stable`. Until the main branch is working, this should be used in tutorial.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the branch name in the tutorial documentation from `rollkit-main` to `rollkit-stable` for the `git checkout` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->