### PR TITLE
fix: Revert "Merge pull request #269 from rollkit/manav/add_centralized_va…

### DIFF
--- a/scripts/cosmwasm/init.sh
+++ b/scripts/cosmwasm/init.sh
@@ -49,12 +49,6 @@ wasmd genesis gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-bac
 # collect gentxs
 wasmd genesis collect-gentxs
 
-# copy centralized sequencer address into genesis.json
-# Note: validator and sequencer are used interchangeably here
-ADDRESS=$(jq -r '.address' ~/.wasm/config/priv_validator_key.json)
-PUB_KEY=$(jq -r '.pub_key' ~/.wasm/config/priv_validator_key.json)
-jq --argjson pubKey "$PUB_KEY" '. + {"validators": [{"address": "'$ADDRESS'", "pub_key": $pubKey, "power": "1000", "name": "Rollkit Sequencer"}]}' ~/.wasm/config/genesis.json > temp.json && mv temp.json ~/.wasm/config/genesis.json
-
 # generate an authorization token for the light client using the celestia binary
 # this is for Arabica, if using another network, change the network name
 export AUTH_TOKEN=$(celestia light auth write --p2p.network mocha)

--- a/scripts/gm/init-local.sh
+++ b/scripts/gm/init-local.sh
@@ -77,12 +77,6 @@ gmd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
 # collect genesis transactions
 gmd collect-gentxs
 
-# copy centralized sequencer address into genesis.json
-# Note: validator and sequencer are used interchangeably here
-ADDRESS=$(jq -r '.address' ~/.gm/config/priv_validator_key.json)
-PUB_KEY=$(jq -r '.pub_key' ~/.gm/config/priv_validator_key.json)
-jq --argjson pubKey "$PUB_KEY" '. + {"validators": [{"address": "'$ADDRESS'", "pub_key": $pubKey, "power": "1000", "name": "Rollkit Sequencer"}]}' ~/.gm/config/genesis.json > temp.json && mv temp.json ~/.gm/config/genesis.json
-
 # export the Celestia light node's auth token to allow you to submit
 # PayForBlobs to Celestia's data availability network
 # this is for Arabica, if using another network, change the network name

--- a/scripts/gm/init-testnet.sh
+++ b/scripts/gm/init-testnet.sh
@@ -44,12 +44,6 @@ gmd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
 # collect genesis transactions
 gmd collect-gentxs
 
-# copy centralized sequencer address into genesis.json
-# Note: validator and sequencer are used interchangeably here
-ADDRESS=$(jq -r '.address' ~/.gm/config/priv_validator_key.json)
-PUB_KEY=$(jq -r '.pub_key' ~/.gm/config/priv_validator_key.json)
-jq --argjson pubKey "$PUB_KEY" '. + {"validators": [{"address": "'$ADDRESS'", "pub_key": $pubKey, "power": "1000", "name": "Rollkit Sequencer"}]}' ~/.gm/config/genesis.json > temp.json && mv temp.json ~/.gm/config/genesis.json
-
 # export the Celestia light node's auth token to allow you to submit
 # PayForBlobs to Celestia's data availability network
 # this is for Arabica, if using another network, change the network name

--- a/scripts/recipes/init.sh
+++ b/scripts/recipes/init.sh
@@ -41,12 +41,6 @@ recipesd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend 
 # collect genesis transactions
 recipesd collect-gentxs
 
-# copy centralized sequencer address into genesis.json
-# Note: validator and sequencer are used interchangeably here
-ADDRESS=$(jq -r '.address' ~/.recipes/config/priv_validator_key.json)
-PUB_KEY=$(jq -r '.pub_key' ~/.recipes/config/priv_validator_key.json)
-jq --argjson pubKey "$PUB_KEY" '. + {"validators": [{"address": "'$ADDRESS'", "pub_key": $pubKey, "power": "1000", "name": "Rollkit Sequencer"}]}' ~/.recipes/config/genesis.json > temp.json && mv temp.json ~/.recipes/config/genesis.json
-
 # export the Celestia light node's auth token to allow you to submit
 # PayForBlobs to Celestia's data availability network
 # this is for Arabica, if using another network, change the network name

--- a/scripts/wordle/init.sh
+++ b/scripts/wordle/init.sh
@@ -41,12 +41,6 @@ wordled gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend t
 # collect genesis transactions
 wordled collect-gentxs
 
-# copy centralized sequencer address into genesis.json
-# Note: validator and sequencer are used interchangeably here
-ADDRESS=$(jq -r '.address' ~/.wordle/config/priv_validator_key.json)
-PUB_KEY=$(jq -r '.pub_key' ~/.wordle/config/priv_validator_key.json)
-jq --argjson pubKey "$PUB_KEY" '. + {"validators": [{"address": "'$ADDRESS'", "pub_key": $pubKey, "power": "1000", "name": "Rollkit Sequencer"}]}' ~/.wordle/config/genesis.json > temp.json && mv temp.json ~/.wordle/config/genesis.json
-
 # export the Celestia light node's auth token to allow you to submit
 # PayForBlobs to Celestia's data availability network
 # this is for Arabica, if using another network, change the network name

--- a/tutorials/cosmwasm.md
+++ b/tutorials/cosmwasm.md
@@ -123,7 +123,7 @@ Cosmos-SDK applications to connect to Celestia's data availability network.
 git clone https://github.com/CosmWasm/wasmd.git
 cd wasmd
 git checkout tags/v0.45.0
-go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.6-rollkit-v0.10.7-no-fraud-proofs-fixed
+go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.3-rollkit-v0.10.5-no-fraud-proofs
 go mod edit -replace github.com/gogo/protobuf=github.com/regen-network/protobuf@v1.3.3-alpha.regen.1
 go mod tidy -compat=1.17
 go mod download

--- a/tutorials/gm-world.md
+++ b/tutorials/gm-world.md
@@ -422,14 +422,14 @@ from inside the `gm` directory:
 ::: code-group
 
 ```bash [local-celestia-devnet]
-go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.6-rollkit-v0.10.7-no-fraud-proofs-fixed
+go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.3-rollkit-v0.10.5-no-fraud-proofs
 go mod edit -replace github.com/gogo/protobuf=github.com/regen-network/protobuf@v1.3.3-alpha.regen.1
 go mod tidy
 go mod download
 ```
 
 ```bash [Arabica Devnet]
-go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.6-rollkit-v0.10.7-no-fraud-proofs-fixed
+go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.3-rollkit-v0.10.5-no-fraud-proofs
 go mod edit -replace github.com/gogo/protobuf=github.com/regen-network/protobuf@v1.3.3-alpha.regen.1
 go mod tidy
 go mod download

--- a/tutorials/recipe-book.md
+++ b/tutorials/recipe-book.md
@@ -61,14 +61,14 @@ To swap out CometBFT for Rollkit, run the following commands:
 ::: code-group
 
 ```bash [local-celestia-devnet]
-go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.6-rollkit-v0.10.7-no-fraud-proofs-fixed
+go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.3-rollkit-v0.10.5-no-fraud-proofs
 go mod edit -replace github.com/gogo/protobuf=github.com/regen-network/protobuf@v1.3.3-alpha.regen.1
 go mod tidy
 go mod download
 ```
 
 ```bash [Arabica Devnet]
-go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.6-rollkit-v0.10.7-no-fraud-proofs-fixed
+go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.3-rollkit-v0.10.5-no-fraud-proofs
 go mod edit -replace github.com/gogo/protobuf=github.com/regen-network/protobuf@v1.3.3-alpha.regen.1
 go mod tidy
 go mod download

--- a/tutorials/wordle.md
+++ b/tutorials/wordle.md
@@ -178,14 +178,14 @@ Run the following command inside the `wordle` directory.
 ::: code-group
 
 ```bash [local-celestia-devnet]
-go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.6-rollkit-v0.10.7-no-fraud-proofs-fixed
+go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.3-rollkit-v0.10.5-no-fraud-proofs
 go mod edit -replace github.com/gogo/protobuf=github.com/regen-network/protobuf@v1.3.3-alpha.regen.1
 go mod tidy
 go mod download
 ```
 
 ```bash [Arabica Devnet]
-go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.6-rollkit-v0.10.7-no-fraud-proofs-fixed
+go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@v0.47.3-rollkit-v0.10.5-no-fraud-proofs
 go mod edit -replace github.com/gogo/protobuf=github.com/regen-network/protobuf@v1.3.3-alpha.regen.1
 go mod tidy
 go mod download


### PR DESCRIPTION
…l_to_genesis"

This reverts commit 462d4ce8a9fbce533d494db2b1975d1335ba76dd, reversing changes made to 6bb0127b63f2505f0f8096766e538bebc5f4588f.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This reverts commit due to issues with new versions as described in #269. The PR was not ready to be merged

https://github.com/rollkit/docs/pull/269#issuecomment-1832034047

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified initialization scripts by removing redundant code related to centralized sequencer address setup.

- **Documentation**
  - Updated tutorials to reflect the change in `cosmos-sdk` version to enhance compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->