### PR TITLE
fix: go has to be 1.20 or below

### DIFF
--- a/tutorials/gm-world.md
+++ b/tutorials/gm-world.md
@@ -49,7 +49,7 @@ to say GM, Gm, or gm. You can think of "GM" as the new version of
 ## Dependencies {#dependencies}
 
 * Operating systems: GNU/Linux or macOS
-* [Golang 1.20+](https://go.dev)
+* [Golang 1.20 or below](https://go.dev)
 * [Ignite CLI v0.27.1](https://github.com/ignite/cli)
 * [Homebrew](https://brew.sh)
 * [wget](https://www.gnu.org/software/wget)


### PR DESCRIPTION
## Overview

I followed the docs' instruction to download go and downloaded the latest version, 1.21. 

I presume go1.21 does not work with the command: `ignite chain build` which is a command in `init-local.sh` from the tutorial.

Because with go1.21:
1. `go mod tidy` adds the directive `toolchain`.
2. `go 1.21.1` in `go.mod` is rejected for version format.

Error I got with go1.21.1:
```
✘ :3: invalid go version '1.21.1': must match format 1.23
:5: unknown directive: toolchain
```

Downgrading to [go1.20.12](https://go.dev/dl/go1.20.12.src.tar.gz) fixed the issue.