### PR TITLE
Fix celestia bridge command to work with container's celestia installation

### DIFF
--- a/tutorials/gm-world.md
+++ b/tutorials/gm-world.md
@@ -310,7 +310,7 @@ write permission is required to submit blobs and can be obtained
 with the following command once your local-celestia-devnet is running:
 
 ```bash
-docker exec $(docker ps -q)  celestia bridge --node.store /home/celestia/bridge/ auth admin
+docker exec $(docker ps -q)  celestia-da bridge --node.store /home/celestia/bridge/ auth admin
 ```
 
 This will give you the local-celestia-devnet bridge node auth token. This


### PR DESCRIPTION
Change the following command:
docker exec $(docker ps -q)  celestia bridge --node.store /home/celestia/bridge/ auth admin

to:
docker exec $(docker ps -q)  celestia-da bridge --node.store /home/celestia/bridge/ auth admin

The docker instance seems to have "celestia" installed as "celestia-da". This fixes the command in the tutorial.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the command reference in the tutorial to align with the latest naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->