### PR TITLE
feat: bump local devnet to v0.12.6 and celestia-da to v0.12.8 for polaris tutorial

### DIFF
--- a/tutorials/gm-world.md
+++ b/tutorials/gm-world.md
@@ -290,7 +290,7 @@ First, run the [`local-celestia-devnet`](https://github.com/rollkit/local-celest
 ```bash
 docker run -t -i \
     -p 26650:26650 -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
-    ghcr.io/rollkit/local-celestia-devnet:v0.12.5
+    ghcr.io/rollkit/local-celestia-devnet:v0.12.6
 ```
 
 The docker image automatically creates a `NAMESPACE_ID`

--- a/tutorials/gm-world.md
+++ b/tutorials/gm-world.md
@@ -290,7 +290,7 @@ First, run the [`local-celestia-devnet`](https://github.com/rollkit/local-celest
 ```bash
 docker run -t -i \
     -p 26650:26650 -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
-    ghcr.io/rollkit/local-celestia-devnet:v0.12.6
+    ghcr.io/rollkit/local-celestia-devnet:v0.12.5
 ```
 
 The docker image automatically creates a `NAMESPACE_ID`

--- a/tutorials/polaris-evm.md
+++ b/tutorials/polaris-evm.md
@@ -267,7 +267,7 @@ docker run -d \
 -p 26658:26658 \
 -p 26659:26659 \
 -v $HOME/.celestia-light-mocha-4/:/home/celestia/.celestia-light-mocha-4/ \
-ghcr.io/rollkit/celestia-da:v0.12.7 \
+ghcr.io/rollkit/celestia-da:v0.12.8 \
 celestia-da light start \
 --p2p.network=mocha \
 --da.grpc.namespace=000000506f6c61726973 \

--- a/tutorials/polaris-evm.md
+++ b/tutorials/polaris-evm.md
@@ -267,7 +267,7 @@ docker run -d \
 -p 26658:26658 \
 -p 26659:26659 \
 -v $HOME/.celestia-light-mocha-4/:/home/celestia/.celestia-light-mocha-4/ \
-ghcr.io/rollkit/celestia-da:v0.12.4-rc1 \
+ghcr.io/rollkit/celestia-da:v0.12.7 \
 celestia-da light start \
 --p2p.network=mocha \
 --da.grpc.namespace=000000506f6c61726973 \

--- a/tutorials/polaris-evm.md
+++ b/tutorials/polaris-evm.md
@@ -28,7 +28,7 @@ Before you can start Polaris EVM, you need to start a
 local-celestia-devnet instance in a separate terminal:
 
 ```bash
-docker run -t -i --platform linux/amd64 -p 26650:26650 -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 ghcr.io/rollkit/local-celestia-devnet:v0.12.5
+docker run -t -i --platform linux/amd64 -p 26650:26650 -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 ghcr.io/rollkit/local-celestia-devnet:v0.12.6
 ```
 
 ## Clone the repo


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

From https://github.com/berachain/polaris/pull/1413
> I've tested this successfully
> 
> * [x]  on local-celestia-devnet v0.12.6. [logs for devnet](https://app.warp.dev/block/n1vZ0O0nT7U4vc4aqzCoe2) & [logs for rollup](https://app.warp.dev/block/96o84VPdPM77YyvRSVRQO5)
> * [x]  on mocha with celestia-da v0.12.8. [logs for light node](https://app.warp.dev/block/5zat1EgTGU02PbqhcHaxk8) with celestia-da & [logs for rollup](https://app.warp.dev/block/C0K2D1GCqiO3ee7YCnytzl) & [celenium](https://mocha.celenium.io/namespace/000000000000000000000000000000000000000000506f6c61726973)



<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Documentation**
	- Updated the tutorial document with the latest versions of the docker images for local development environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->