### PR TITLE
feat: remove celestia+hyperlane tutorial

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -217,7 +217,6 @@ function sidebarHome() {
           items: [
             { text: 'Full and sequencer node rollup setup', link: '/tutorials/full-and-sequencer-node'},
             { text: 'Full-stack modular dapp with Celestia', link: 'https://docs.celestia.org/developers/full-stack-modular-development-guide'},
-            { text: 'Hyperlane + Celestia tutorial', link: 'https://docs.hyperlane.xyz/docs/deploy/celestia-+-hyperlane'},
           ]
         },
         {

--- a/learn/building-and-deploying-a-rollup.md
+++ b/learn/building-and-deploying-a-rollup.md
@@ -23,7 +23,6 @@ You can get started with the following tutorials:
 ## 3️. Advanced {#advanced}
 
 - [Full-stack modular dapp with Celestia](https://docs.celestia.org/developers/full-stack-modular-development-guide)
-- [Hyperlane + Celestia tutorial](https://docs.hyperlane.xyz/docs/deploy/celestia-+-hyperlane)
 
 ## 💻 Support {#support}
 

--- a/learn/intro.md
+++ b/learn/intro.md
@@ -54,7 +54,6 @@ If you're familiar with Rollkit, you may want to skip to the [tutorials section]
 
 - [Full and sequencer node rollup setup](/tutorials/full-and-sequencer-node)
 - [Full-stack modular dapp with Celestia](https://docs.celestia.org/developers/full-stack-modular-development-guide)
-- [Hyperlane + Celestia tutorial](https://docs.hyperlane.xyz/docs/deploy/celestia-+-hyperlane)
 
 ### Guides
 

--- a/tutorials/overview.md
+++ b/tutorials/overview.md
@@ -28,7 +28,6 @@ In this section, you'll find:
 * Advanced
   * [Full and sequencer node rollup setup](/tutorials/full-and-sequencer-node.md)
   * [Full-stack modular dapp with Celestia](https://docs.celestia.org/developers/full-stack-modular-development-guide)
-  * [Hyperlane + Celestia tutorial](https://docs.hyperlane.xyz/docs/deploy-hyperlane)
 * Guides
   * [How to change speed of block production](/tutorials/block-times.md)
   * [How to use lazy sequencing (aggregation)](/tutorials/lazy-sequencing.md)


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR removes an old Hyperlane + Celestia tutorial.

There are no results for rollkit, and 1 result for celestia in hyperlane docs: https://docs.hyperlane.xyz/docs/guides/ecosystems/celestia
<img width="835" alt="screenshot 2024-01-23 at 14 51 00" src="https://github.com/rollkit/docs/assets/46639943/9ad60d4a-2aa5-4977-aa67-2ca51f0832c1">


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed "Hyperlane + Celestia tutorial" link from various documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->