### PR TITLE
Add a check for $GOPATH

### DIFF
--- a/scripts/gm/init-local.sh
+++ b/scripts/gm/init-local.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Check if GOPATH is set
+if [ -z "$GOPATH" ]; then
+    echo "GOPATH is not set. Please set GOPATH before proceeding."
+    exit 1
+fi
+
 # set variables for the chain
 VALIDATOR_NAME=validator1
 CHAIN_ID=gm


### PR DESCRIPTION
Doesn't allow for a `chain build` process to start if $GOPATH isn't set, because if it isn't then daemon won't install and `<project>d command not found` will be an exception thrown by the system. 

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the initialization script by adding a check for the `GOPATH` environment variable to ensure it's set before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->