### PR TITLE
add auth token to full node script

### DIFF
--- a/scripts/gm/init-full-node.sh
+++ b/scripts/gm/init-full-node.sh
@@ -10,6 +10,11 @@ cp -R "$HOME/.gm/config/genesis.json" "$BASE_DIR/config/genesis.json"
 DA_BLOCK_HEIGHT=your-block-height
 P2P_ID="your-p2p-id"
 
+# uses the same celestia-node as sequencer node
+# if you are running a separate celestia-node for full node
+# use the auth token from that node
+AUTH_TOKEN=$(docker exec $(docker ps -q) celestia bridge auth admin --node.store /home/celestia/bridge)
+
 # rollkit logo
 cat <<'EOF'
 
@@ -44,4 +49,4 @@ cat <<'EOF'
 
 EOF
 
-gmd start --rollkit.da_namespace 00000000000000000000000000000000000000000008e5f679bf7116cb --rollkit.da_start_height $DA_BLOCK_HEIGHT --rpc.laddr tcp://127.0.0.1:46657 --grpc.address 127.0.0.1:9390 --p2p.seeds $P2P_ID@127.0.0.1:36656 --p2p.laddr "0.0.0.0:46656" --log_level debug --minimum-gas-prices="0.025stake" --home $BASE_DIR
+gmd start --rollkit.da_auth_token=$AUTH_TOKEN --rollkit.da_namespace 00000000000000000000000000000000000000000008e5f679bf7116cb --rollkit.da_start_height $DA_BLOCK_HEIGHT --rpc.laddr tcp://127.0.0.1:46657 --grpc.address 127.0.0.1:9390 --p2p.seeds $P2P_ID@127.0.0.1:36656 --p2p.laddr "0.0.0.0:46656" --log_level debug --minimum-gas-prices="0.025stake" --home $BASE_DIR

--- a/tutorials/full-and-sequencer-node.md
+++ b/tutorials/full-and-sequencer-node.md
@@ -89,6 +89,15 @@ P2P_ID="your-p2p-id" // [!code --]
 P2P_ID="12D3KooWCmfJLkQjZUArWpNUDJSezeFiLYzCULXe1dEKY6ZpXZpk" // [!code ++]
 ```
 
+Also, in your `init-full-node.sh` script, the `AUTH_TOKEN` is fetched from the celestia-node running in the docker, which is also used by the sequencer node. If you are running a separate celestia-node for sequencer and full node, please update the `AUTH_TOKEN` accordingly. Note that, the `AUTH_TOKEN` is needed to perform DA queries via celestia-node.
+
+```bash
+# uses the same celestia-node as sequencer node
+# if you are running a separate celestia-node for full node
+# use the auth token from that node
+AUTH_TOKEN=$(docker exec $(docker ps -q) celestia bridge auth admin --node.store /home/celestia/bridge)
+```
+
 ## Start the full node
 
 Now run your full node with the script:


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the initialization script for full nodes to dynamically retrieve and use an authentication token from a Celestia node.
- **Documentation**
	- Updated the tutorial for setting up full and sequencer nodes with instructions on fetching the `AUTH_TOKEN` from the Celestia node, highlighting the requirement for separate tokens for different node types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->