### PR TITLE
feat: links to github instead of scripts, because scripts download automatically

### DIFF
--- a/tutorials/cosmwasm.md
+++ b/tutorials/cosmwasm.md
@@ -172,7 +172,7 @@ that communicates between `wasmd` and Rollkit.
 
 ### 🗞️ Initializing CosmWasm rollup with a bash script {#initialize-rollup}
 
-We have a handy `init.sh` [found in this repo](https://rollkit.dev/cosmwasm/init.sh).
+We have a handy `init.sh` [found in this repo](https://github.com/rollkit/docs/blob/main/public/cosmwasm/init.sh).
 
 We can copy it over to our directory with the following commands:
 

--- a/tutorials/gm-world-arabica-testnet.md
+++ b/tutorials/gm-world-arabica-testnet.md
@@ -31,7 +31,7 @@ Keep the node running while doing the next steps.
 ### 🟢 Start your sovereign rollup {#start-your-sovereign-rollup}
 
 We have
-[a handy `init-arabica-testnet.sh` found in this repo](https://rollkit.dev/gm/init-arabica-testnet.sh).
+[a handy `init-arabica-testnet.sh` found in this repo](https://github.com/rollkit/docs/blob/main/public/gm/init-arabica-testnet.sh).
 
 We can copy it over to our directory with the following commands:
 

--- a/tutorials/gm-world-mocha-testnet.md
+++ b/tutorials/gm-world-mocha-testnet.md
@@ -31,7 +31,7 @@ After the node is synced, stop the light node.
 ### 🟢 Start your sovereign rollup {#start-your-sovereign-rollup}
 
 We have
-[a handy `init-mocha-testnet.sh` found in this repo](https://rollkit.dev/gm/init-mocha-testnet.sh).
+[a handy `init-mocha-testnet.sh` found in this repo](https://github.com/rollkit/docs/blob/main/public/gm/init-mocha-testnet.sh).
 
 We can copy it over to our directory with the following commands:
 

--- a/tutorials/gm-world.md
+++ b/tutorials/gm-world.md
@@ -6,7 +6,7 @@ description: Build a sovereign rollup with Ignite CLI, Celestia, and Rollkit loc
 
 ## 🌞Introduction {#introduction}
 
-This tutorial will guide you through building a sovereign `gm-world` rollup (`gm` stands for "good morning") using Rollkit. Unlike the [Quick start guide](https://rollkit.dev/tutorials/quick-start), this tutorial provides a more practical approach to understanding sovereign rollup development.
+This tutorial will guide you through building a sovereign `gm-world` rollup (`gm` stands for "good morning") using Rollkit. Unlike the [quick start guide](https://rollkit.dev/tutorials/quick-start), this tutorial provides a more practical approach to understanding sovereign rollup development.
 
 We will cover:
 

--- a/tutorials/gm-world.md
+++ b/tutorials/gm-world.md
@@ -6,7 +6,7 @@ description: Build a sovereign rollup with Ignite CLI, Celestia, and Rollkit loc
 
 ## 🌞Introduction {#introduction}
 
-This tutorial will guide you through building a sovereign `gm-world` rollup (`gm` stands for "good morning") using Rollkit. Unlike the [Quick Start Guide](https://rollkit.dev/tutorials/quick-start), this tutorial provides a more practical approach to understanding sovereign rollup development.
+This tutorial will guide you through building a sovereign `gm-world` rollup (`gm` stands for "good morning") using Rollkit. Unlike the [Quick start guide](https://rollkit.dev/tutorials/quick-start), this tutorial provides a more practical approach to understanding sovereign rollup development.
 
 We will cover:
 

--- a/tutorials/wordle.md
+++ b/tutorials/wordle.md
@@ -575,7 +575,7 @@ test, and launch your own sovereign rollup.
 
 ### 🟢 Building and running wordle chain {#build-and-run-wordle-chain}
 
-We have a handy `init.sh` [found in this repo](https://rollkit.dev/wordle/init.sh).
+We have a handy `init.sh` [found in this repo](https://github.com/rollkit/docs/blob/main/public/wordle/init.sh).
 
 We can copy it over to our directory with the following commands:
 


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR makes changes to "handy script" links to show the example on github as opposed to the hosted script on rollkit.dev/*/init-*.sh to avoid the script downloading and to allow the user to preview the script.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
    - Updated links to initialization scripts in various tutorials to point to new GitHub repository locations, enhancing accessibility and reliability.
    - Minor text modification in the "Quick Start Guide" title for consistency in documentation style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->