### PR TITLE
Move quickstart out of Rollkit section

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -193,13 +193,13 @@ function sidebarHome() {
       collapsed: true,
       items: [
         {
+          text: "Quick start guide",
+          link: "/tutorials/quick-start",
+        },
+        {
           text: "Rollkit",
           collapsed: true,
           items: [
-            {
-              text: "Quick start guide",
-              link: "/tutorials/quick-start",
-            },
             {
               text: "GM world rollup",
               link: "/tutorials/gm-world",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Moved the "Quick Start Guide" from the "Rollkit" section to the "Tutorials" section in the sidebar navigation for enhanced accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->