### PR TITLE
docs: update rm gmd command

### DIFF
--- a/tutorials/celestia-da.md
+++ b/tutorials/celestia-da.md
@@ -25,7 +25,7 @@ From the [GM world rollup](/tutorials/gm-world) tutorial, you should already hav
 To clear old rollup data:
 
 ```bash
-rm -r /usr/local/bin/gmd && rm -rf $HOME/.gm
+rm -r $(which gmd) && rm -rf $HOME/.gm
 ```
 
 ## 🏗️ Building your rollup


### PR DESCRIPTION
binary is found in go bin, not usr/bin:

```bash
$ which gmd
/Users/joshstein/go/bin/gmd
```

Updating this command to remove binary in location of `which gmd` instead.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `celestia-da.md` tutorial to use the `which` command for clearing old rollup data, improving clarity and ease of use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->