### PR TITLE
Update to use rollkit cli instead of <binary>d

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -255,45 +255,67 @@ function sidebarHome() {
       collapsed: true,
       items: [
         {
+          text: "Configuration",
+          collapsed: true,
           items: [
             {
-              text: "How to restart your rollup",
+              text: "Use the Rollkit CLI",
+              link: "/guides/use-rollkit-cli",
+            },
+            {
+              text: "Connect to a local DA",
+              link: "/guides/connect-local-da",
+            },
+            {
+              text: "Create genesis for your rollup",
+              link: "/guides/create-genesis",
+            },
+            {
+              text: "Restart your rollup",
               link: "/guides/restart-rollup",
             },
             {
-              text: "How to run as a full and sequencer node",
+              text: "Run as a full and sequencer node",
               link: "/guides/full-and-sequencer-node",
             },
             {
-              text: "How to configure gas price",
+              text: "Configure gas price",
               link: "/guides/gas-price",
             },
             {
-              text: "How to change speed of block production",
+              text: "Configure max pending blocks",
+              link: "/guides/max-pending-blocks",
+            },
+            {
+              text: "Configure DA chain block sync time",
+              link: "/guides/da-block-time",
+            },
+            {
+              text: "Change speed of block production",
               link: "/guides/block-times",
             },
             {
-              text: "How to use lazy sequencing (aggregation)",
+              text: "Use lazy sequencing (aggregation)",
               link: "/guides/lazy-sequencing",
             },
-            {
-              text: "How to test and deploy smart-contracts",
-              link: "/guides/cw-orch",
-            },
-            { text: "How to add zkML to your rollup", link: "/guides/zkml" },
-            {
-              text: "How to add an IBC connection to your rollup",
-              link: "/guides/ibc-connection",
-            },
-            {
-              text: "How to integrate Range with your rollup",
-              link: "/guides/rollkit-monitoring",
-            },
-            {
-              text: "How to use IBC token (TIA) as gas token in your rollup",
-              link: "/guides/use-tia-for-gas",
-            },
           ],
+        },
+        {
+          text: "Test and deploy smart-contracts",
+          link: "/guides/cw-orch",
+        },
+        { text: "Add zkML to your rollup", link: "/guides/zkml" },
+        {
+          text: "Add an IBC connection to your rollup",
+          link: "/guides/ibc-connection",
+        },
+        {
+          text: "Integrate Range with your rollup",
+          link: "/guides/rollkit-monitoring",
+        },
+        {
+          text: "Use IBC token (TIA) as gas token in your rollup",
+          link: "/guides/use-tia-for-gas",
         },
       ],
     },

--- a/.vitepress/constants/constants.js
+++ b/.vitepress/constants/constants.js
@@ -10,6 +10,6 @@ const constants = Object.freeze({
 
   localDALatestTag: "v0.2.0",
 
-  igniteVersionTag: "v28.3.0",
+  igniteVersionTag: "v28.4.0",
 });
 export default constants;

--- a/guides/connect-local-da.md
+++ b/guides/connect-local-da.md
@@ -1,0 +1,31 @@
+# How to connect a rollup to a local DA network
+
+This guide provides a quick and straightforward method to start a local Data Availability (DA) network and configure your rollup to post data to it.
+
+## Setting Up a Local DA Network
+
+To set up a local DA network node on your machine, run the following script to install and start the local DA node:
+
+```bash
+curl -sSL https://rollkit.dev/install-local-da.sh | bash -s {{constants.localDALatestTag}}
+```
+
+This script will build and run the node, which will then listen on port `7980`.
+
+## Configuring your rollup to connect to the local DA network
+
+To connect your rollup to the local DA network, you need to pass the `--rollkit.da_address` flag with the local DA node address.
+
+## Run your rollup
+
+Start your rollup node with the following command, ensuring to include the DA address flag:
+
+```bash
+rollkit start \
+    --rollkit.da_address http://localhost:7980 \
+    <other-flags>
+```
+
+## Summary
+
+By following these steps, you will set up a local DA network node and configure your rollup to post data to it. This setup is useful for testing and development in a controlled environment.

--- a/guides/create-genesis.md
+++ b/guides/create-genesis.md
@@ -1,0 +1,112 @@
+# How to create a genesis for your rollup
+
+This guide will walk you through the process of setting up a genesis for your rollup. Follow the steps below to initialize your rollup chain, add a genesis account, and start the chain.
+
+## 1. Setting variables
+
+First, set the necessary variables for your chain, here is an example:
+
+```sh
+VALIDATOR_NAME=validator1
+CHAIN_ID=rollup-chain
+KEY_NAME=rollup-key
+CHAINFLAG="--chain-id ${CHAIN_ID}"
+TOKEN_AMOUNT="10000000000000000000000000stake"
+STAKING_AMOUNT="1000000000stake"
+```
+
+## 2. Ensuring `rollkit.toml` is present and building entrypoint
+
+Ensure that `rollkit.toml` is present in the root of your rollup directory (if not, follow a [Guide](/guides/use-rollkit-cli) to set it up) and run the following command to (re)generate an entrypoint binary out of the code:
+
+```sh
+rollkit rebuild
+```
+
+This creates an `entrypoint` binary in the root of your rollup directory. which is used to run all the operations on the rollup chain.
+
+Ensure that the chain configuration directory is set correctly in the `rollkit.toml` file, if you doubt it, you can remove the `rollkit.toml` file and run the following command to generate a new one:
+
+```sh
+rollkit toml init
+```
+
+## 3. Resetting existing genesis/chain data
+
+Reset any existing genesis or chain data:
+
+```sh
+rollkit tendermint unsafe-reset-all
+```
+
+## 4. Initializing the validator
+
+Initialize the validator with the chain ID you set:
+
+```sh
+rollkit init $VALIDATOR_NAME --chain-id $CHAIN_ID
+```
+
+## 5. Adding a key to keyring backend
+
+Add a key to the keyring-backend:
+
+```sh
+rollkit keys add $KEY_NAME --keyring-backend test
+```
+
+## 6. Adding a genesis account
+
+Add a genesis account with the specified token amount:
+
+```sh
+rollkit genesis add-genesis-account $KEY_NAME $TOKEN_AMOUNT --keyring-backend test
+```
+
+## 7. Setting the staking amount in the genesis transaction
+
+Set the staking amount in the genesis transaction:
+
+```sh
+rollkit genesis gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
+```
+
+## 8. Collecting genesis transactions
+
+Collect the genesis transactions:
+
+```sh
+rollkit genesis collect-gentxs
+```
+
+## 9. Configuring the genesis file
+
+Copy the centralized sequencer address into `genesis.json`:
+
+```sh
+ADDRESS=$(jq -r '.address' ~/.rollup/config/priv_validator_key.json)
+PUB_KEY=$(jq -r '.pub_key' ~/.rollup/config/priv_validator_key.json)
+jq --argjson pubKey "$PUB_KEY" '.consensus["validators"]=[{"address": "'$ADDRESS'", "pub_key": $pubKey, "power": "1000", "name": "Rollkit Sequencer"}]' ~/.rollup/config/genesis.json > temp.json && mv temp.json ~/.rollup/config/genesis.json
+```
+
+## 10. Creating a restart script
+
+Create a `restart-rollup.sh` file to restart the chain later, notice the `rollkit.da_address` flag which is the address of the data availability node, for other DA layers it will be a different set of flags (in case of Celestia check out the tutorial [here](/tutorials/celestia-da)):
+
+```sh
+[ -f restart-rollup.sh ] && rm restart-rollup.sh
+
+echo "rollkit start --rollkit.aggregator --rpc.laddr tcp://127.0.0.1:36657 --grpc.address 127.0.0.1:9290 --p2p.laddr \"0.0.0.0:36656\" --minimum-gas-prices=\"0.025stake\" --rollkit.da_address \"http://localhost:7980\"" >> restart-rollup.sh
+```
+
+## 11. Starting the chain
+
+Finally, start the chain with the following command:
+
+```sh
+rollkit start --rollkit.aggregator --rpc.laddr tcp://127.0.0.1:36657 --grpc.address 127.0.0.1:9290 --p2p.laddr "0.0.0.0:36656" --minimum-gas-prices="0.025stake" --rollkit.da_address "http://localhost:7980"
+```
+
+## Summary
+
+By following these steps, you will set up the genesis for your rollup, initialize the validator, add a genesis account, and start the chain on a local data availability network (DA). This guide provides a basic framework for configuring and starting your rollup using the Rollkit CLI. Make sure `rollkit.toml` is present in the root of your rollup directory, and use the `rollkit` command for all operations.

--- a/guides/da-block-time.md
+++ b/guides/da-block-time.md
@@ -1,6 +1,6 @@
 # How to configure DA chain block syncing time
 
-The `--rollkit.da_block_time` flag is used to configure the time in seconds that the rollup will wait for a block to be synced from the DA chain. 
+The `--rollkit.da_block_time` flag is used to configure the time in seconds that the rollup will wait for a block to be synced from the DA chain.
 
 ```bash
 --rollkit.da_block_time duration

--- a/guides/da-block-time.md
+++ b/guides/da-block-time.md
@@ -1,0 +1,14 @@
+# How to configure DA chain block syncing time
+
+The `--rollkit.da_block_time` flag is used to configure the time in seconds that the rollup will wait for a block to be synced from the DA chain. 
+
+```bash
+--rollkit.da_block_time duration
+```
+
+An example command would look like this:
+
+```bash
+rollkit start [existing flags...] // [!code --]
+rollkit start [existing flags...] --rollkit.da_block_time=30s // [!code ++]
+```

--- a/guides/max-pending-blocks.md
+++ b/guides/max-pending-blocks.md
@@ -1,0 +1,15 @@
+# How to configure the maximum number of blocks pending DA submission
+
+The `--rollkit.max_pending_blocks` flag is used to configure the maximum limit of blocks pending DA submission (0 for no limit)
+
+```bash
+--rollkit.max_pending_blocks uint
+```
+
+An example command would look like this:
+
+```bash
+rollkit start [existing flags...] // [!code --]
+rollkit start [existing flags...] --rollkit.max_pending_blocks=100 // [!code ++]
+```
+

--- a/guides/use-rollkit-cli.md
+++ b/guides/use-rollkit-cli.md
@@ -1,0 +1,73 @@
+# How to Use Rollkit CLI
+
+This guide will walk you through the basics of installing and using Rollkit CLI. You'll learn how to install the CLI, initialize a configuration file (`rollkit.toml`), and run rollup commands.
+
+## 1. Installing Rollkit CLI
+
+<!-- markdownlint-disable MD033 -->
+<script setup>
+import constants from '../.vitepress/constants/constants.js'
+</script>
+
+To install Rollkit CLI, execute the following command:
+
+```bash-vue
+curl -sSL https://rollkit.dev/install.sh | sh -s {{constants.rollkitLatestTag}}
+```
+
+This command downloads and installs the Rollkit CLI of specified version.
+
+## 2. Initializing `rollkit.toml`
+
+The `rollkit.toml` file is a configuration file that Rollkit uses to understand the structure and entry point of your rollup. To initialize this file, follow these steps:
+
+### Steps to Generate `rollkit.toml`:
+
+1. Run the following command to generate the `rollkit.toml` file:
+
+    ```bash
+    rollkit toml init
+    ```
+
+2. You should see an output similar to this (example taken from [GM world](/tutorials/gm-world) tutorial):
+
+    ```bash
+    Found rollup entrypoint: /root/gm/cmd/gmd/main.go, adding to rollkit.toml
+    Could not find rollup config under gm. Please put the chain.config_dir in the rollkit.toml file manually.
+    Initialized rollkit.toml file in the current directory.
+    ```
+
+3. The output indicates that the rollup entrypoint is `~/gm/cmd/gmd/main.go`.
+
+4. Open the `rollkit.toml` file, and under the `[chain]` section, set `config_dir` to the appropriate directory where your chain configuration is. For GM World tutorial, `rollkit.toml` file looks like this:
+
+    ```toml
+    entrypoint = "./cmd/gmd/main.go"
+
+    [chain]
+      config_dir = "./.gm"
+    ```
+
+    Adjust `entrypoint` and `config_dir` according to your project structure.
+
+## 3. Running Rollup Commands Using Rollkit CLI
+
+Once you have the `rollkit.toml` file set up, you can run any rollup command using the Rollkit CLI. Ensure you are in the directory containing the `rollkit.toml` file when executing commands.
+
+### Example:
+
+1. Navigate to the directory containing the `rollkit.toml` file.
+
+2. Now you could do:
+
+    ```bash
+    # instead of <rollup>d start
+    rollkit start 
+    # instead of <rollup>d tx
+    rollkit tx
+    # for any <rollup>d <command>
+    rollkit <command>
+    ```
+## Summary
+
+By following these steps, you can install the Rollkit CLI, initialize the `rollkit.toml` configuration file, and run rollup commands. This setup helps you manage and interact with your rollup project efficiently.

--- a/public/install-gm-rollup.sh
+++ b/public/install-gm-rollup.sh
@@ -3,6 +3,4 @@
 echo "Downloading GM tutorial rollup source code..."
 git clone https://github.com/rollkit/gm.git
 cd gm || { echo "Failed to find the downloaded repository"; exit 1; }
-git fetch && git checkout remotes/origin/tutorial-local-da
-echo "Building and configuring rollup chain..."
-bash init.sh
+git fetch && git checkout remotes/origin/tutorial-local-da-rollkit

--- a/tutorials/celestia-da.md
+++ b/tutorials/celestia-da.md
@@ -1,10 +1,10 @@
-# GM world rollup: Deploying to Celestia  
+# Deploying a rollup to Celestia  
 
 ## 🌞 Introduction {#introduction}
 
-This tutorial serves as a comprehensive guide for deploying your GM world rollup on Celestia's data availability (DA) network. From the Rollkit perspective, there's no difference in posting blocks to Celestia's testnets or Mainnet Beta.
+This tutorial serves as a comprehensive guide for deploying your rollup on Celestia's data availability (DA) network. From the Rollkit perspective, there's no difference in posting blocks to Celestia's testnets or Mainnet Beta.
 
-Before proceeding, ensure that you have completed the [GM world rollup](/tutorials/gm-world) tutorial, which covers setting up a local sovereign gm-world rollup and connecting it to a local (mock) DA node.
+Before proceeding, ensure that you have completed the [GM world rollup](/tutorials/gm-world) tutorial, which covers setting up a local sovereign gm-world rollup and connecting it to a local DA node.
 
 ## 🪶 Running a Celestia light node
 
@@ -18,29 +18,61 @@ The main difference lies in how you fund your wallet address: using testnet TIA 
 
 After successfully starting a light node, it's time to start posting the batches of blocks of data that your rollup generates.
 
-## 🧹 Cleaning previous chain history
+## 🏗️  Prerequisites {#prerequisites}
 
-From the [GM world rollup](/tutorials/gm-world) tutorial, you should already have the `gmd` binary and the `$HOME/.gm` directory.
+From the [GM world rollup](/tutorials/gm-world) tutorial, you should already have the `rollkit` CLI and `ignite` installed.
 
-To clear old rollup data:
+## 🏗️ Building your sovereign rollup {#building-your-sovereign-rollup}
 
-```bash
-rm -r $(which gmd) && rm -rf $HOME/.gm
-```
-
-## 🏗️ Building your rollup
-
-Now we need to rebuild our rollup by simply running the existing `init.sh` script:
+Remove the existing `gm` project and create a new one using ignite:
 
 ```bash
-cd $HOME/gm && bash init.sh
+cd $HOME && rm -rf gm
+ignite scaffold chain gm --address-prefix gm --no-module
 ```
 
-This process creates a new `$HOME/.gm` directory and a new `gmd` binary. Next, we need to connect our rollup to the running Celestia light node.
+Install the Rollkit app to ignite:
+
+```bash
+ignite app install github.com/ignite/apps/rollkit@rollkit/v0.2.0
+```
+
+Next, move to the `gm` directory and add the Rollkit app:
+
+```bash
+cd $HOME/gm
+ignite rollkit add
+```
+
+Initialize the Rollkit chain configuration:
+
+```bash
+ignite rollkit init
+```
+
+This will create a `$HOME/.gm` directory with the chain configuration files.
+
+
+## 🧰 Configuring your rollup {#configuring-your-rollup}
+
+
+From inside the `$HOME/gm` directory, generate a rollkit.toml file by running:
+
+```bash
+rollkit toml init
+```
+
+The output should be similar to this (our `$HOME` is `/root`):
+
+```
+Found rollup entrypoint: /root/gm/cmd/gmd/main.go, adding to rollkit.toml
+Found rollup configuration under /root/.gm, adding to rollkit.toml
+Initialized rollkit.toml file in the current directory.
+```
 
 ## 🛠️ Configuring flags for DA
 
-Now we're prepared to initiate our rollup and establish a connection with the Celestia light node. The `gmd start` command requires three DA configuration flags:
+Now we're prepared to initiate our rollup and establish a connection with the Celestia light node. The `rollkit start` command requires three DA configuration flags:
 
 - `--rollkit.da_start_height`
 - `--rollkit.da_auth_token`
@@ -100,7 +132,7 @@ Replace the last 20 characters (10 bytes) in `0000000000000000000000000000000000
 Now let's run our rollup node with all DA flags:
 
 ```bash
-gmd start \
+rollkit start \
     --rollkit.aggregator \
     --rollkit.da_auth_token $AUTH_TOKEN \
     --rollkit.da_namespace $DA_NAMESPACE \

--- a/tutorials/gm-world.md
+++ b/tutorials/gm-world.md
@@ -29,19 +29,13 @@ import constants from '../.vitepress/constants/constants.js'
 
 ## 🛠️ Dependencies {#dependencies}
 
-Rollkit uses the [Go programming language](https://go.dev/dl/). Here's how to install it:
+If you followed the [quick start guide](/tutorials/quick-start), you should have the Rollkit CLI and Golang installed already. If not, here's the script for you:
 
-- **Linux or macOS**: Run the provided script:
+```bash-vue
+curl -sSL https://rollkit.dev/install.sh | sh -s {{constants.rollkitLatestTag}}
+```
 
-  ```bash-vue
-  curl -sSL https://rollkit.dev/install-go.sh | bash -s {{constants.golangVersion}}
-  ```
-
-<!-- markdownlint-disable MD033 -->
-- **Windows**: Download and execute the <a :href="`https://go.dev/dl/go${constants.golangVersion}.windows-amd64.msi`">installer</a>.
-<!-- markdownlint-enable MD033 -->
-
-## 🌐 Running a Local DA Network {#running-local-da}
+## 🌐 Running a local DA network {#running-local-da}
 
 Learn to run a local DA network, designed for educational purposes, on your machine.
 
@@ -57,19 +51,36 @@ This script builds and runs the node, now listening on port `7980`.
 
 With the local DA network running, let’s prepare your rollup blockchain.
 
-To make it simple we will download a repository with a `gm-world` rollup that has an `init.sh` script that does all the setup for you.
-
-Download and build a `gm-world` rollup with an interactive script in a new terminal:
-
-::: warning
-In order to run it you need to have the jq command line tool installed. You can install it by running `sudo apt-get install jq` on Ubuntu or `brew install jq` on macOS.
-:::
-::: tip
-If you get errors of `gmd` not found, you may need to add the `go/bin` directory to your PATH. You can do this by running `export PATH=$PATH:$HOME/go/bin` and then running the `init.sh` script manually again.
-:::
+To make it simple, we will download a repository with a `gm-world` rollup that has all app chain config set up for you:
 
 ```bash
 cd $HOME && bash -c "$(curl -sSL https://rollkit.dev/install-gm-rollup.sh)"
+```
+
+## 🧰 Configuring your rollup {#configuring-your-rollup}
+
+Generate rollkit.toml file by running:
+
+```bash
+rollkit toml init
+```
+
+The output should be similar to this:
+```
+Found rollup entrypoint: /root/gm/cmd/gmd/main.go, adding to rollkit.toml
+Could not find rollup config under gm. Please put the chain.config_dir in the rollkit.toml file manually.
+Initialized rollkit.toml file in the current directory.
+```
+
+From the output, you can see that the rollup entrypoint is `~/gm/cmd/gmd/main.go`.
+
+Open the rollkit.toml file and under the `[chain]` section set `config_dir` to the `./.gm` directory. Your rollkit.toml file should look like this:
+
+```bash
+entrypoint = "./cmd/gmd/main.go"
+
+[chain]
+  config_dir = "./.gm"
 ```
 
 ## 🚀 Starting your rollup {#start-your-rollup}
@@ -77,10 +88,10 @@ cd $HOME && bash -c "$(curl -sSL https://rollkit.dev/install-gm-rollup.sh)"
 Start the rollup, posting to the local DA network:
 
 ```bash
-gmd start --rollkit.aggregator --minimum-gas-prices="0.025stake" --rollkit.da_address http://localhost:7980
+rollkit start --rollkit.aggregator --rollkit.da_address http://localhost:7980
 ```
 
-Notice how we specified the DA network address along with a few other flags. Now you should see the logs of the running node:
+Notice how we specified the DA network address. Now you should see the logs of the running node:
 
 ```bash
 12:21PM INF starting node with ABCI CometBFT in-process module=server
@@ -117,7 +128,7 @@ Good work so far, we have a Rollup node, DA network node, now we can start submi
 First, list your keys:
 
 ```bash
-gmd keys list --keyring-backend test
+rollkit keys list --keyring-backend test
 ```
 
 You should see an output like the following
@@ -144,10 +155,10 @@ export KEY1=gm18k57hn42ujcccyn0n5v7r6ydpacycn2wkt7uh9
 export KEY2=gm1e4fqspwdsy0dzkmzsdhkadfcrd0udngw0f88pw
 ```
 
-Now let's submit a transaction that sends coins from one account to another (don't worry about all the flags, for now, we just want to submit transaction from a high level perspective):
+Now let's submit a transaction that sends coins from one account to another (don't worry about all the flags, for now, we just want to submit transaction from a high-level perspective):
 
 ```bash
-gmd tx bank send $KEY1 $KEY2 42069stake --keyring-backend test --chain-id gm --fees 5000stake
+rollkit tx bank send $KEY1 $KEY2 42069stake --keyring-backend test --chain-id gm --fees 5000stake
 ```
 
 You'll be prompted to accept the transaction:
@@ -190,7 +201,7 @@ txhash: 677CAF6C80B85ACEF6F9EC7906FB3CB021322AAC78B015FA07D5112F2F824BFF
 Query balances after the transaction:
 
 ```bash
-gmd query bank balances $KEY2 
+rollkit query bank balances $KEY2
 ```
 
 The receiver’s balance should show an increase.
@@ -207,7 +218,7 @@ pagination:
 For the sender’s balance:
 
 ```bash
-gmd query bank balances $KEY1
+rollkit query bank balances $KEY1
 ```
 
 Output:

--- a/tutorials/wordle.md
+++ b/tutorials/wordle.md
@@ -85,7 +85,6 @@ To install Ignite, you can run this command in your terminal:
 
 ```bash-vue
 curl https://get.ignite.com/cli@{{constants.igniteVersionTag}}! | bash
-sudo mv ignite /usr/local/bin/
 ```
 
 This installs Ignite CLI in your local machine.
@@ -120,8 +119,8 @@ you must write yourself. If you are coming from the EVM-world, think of
 Ignite as a Cosmos-SDK version of Foundry or Hardhat but specifically
 designed to build blockchains.
 
-We first run the following command to setup our project for
-our new blockchain, Wordle.
+we first run the following command to set up our project for
+our new blockchain, wordle.
 
 ```bash
 ignite scaffold chain wordle --no-module
@@ -167,16 +166,26 @@ Rollkit on our codebase.
 
 ### 🗞️ Installing Rollkit {#installing-rollkit}
 
-Run the following command inside the `wordle` directory.
+To install the Rollkit app to Ignite, run the following command:
 
-```bash-vue
-go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/rollkit/cosmos-sdk@{{constants.rollkitCosmosSDKVersion}}
-go mod tidy
-go mod download
+```bash
+ignite app install github.com/ignite/apps/rollkit@rollkit/v0.2.0
 ```
 
-With that, we have Rollkit changes added to the project directory. Now,
-let's build the Wordle app!
+Next, add Rollkit to your project by running:
+
+```bash
+ignite rollkit add
+```
+
+Initialize the Rollkit chain configuration for a local DA network with this command:
+
+```bash
+ignite rollkit init --local-da
+```
+
+This will create a `~/.wordle` directory with all the necessary files to run a rollup on a local DA network.
+With these steps, Rollkit is now added. Let's build the Wordle app!
 
 ## ✨ Creating the wordle module {#creating-wordle-module}
 
@@ -550,7 +559,7 @@ compile the blockchain and take it out for a test drive.
 To set up a local data availability network node run:
 
 ```bash-vue
-curl -sSL https://rollkit.dev/install-local-da.sh | sh {{constants.localDALatestTag}} 
+curl -sSL https://rollkit.dev/install-local-da.sh | sh -s {{constants.localDALatestTag}}
 ```
 
 This script builds and runs the node, now listening on port `7980`.
@@ -560,36 +569,26 @@ running on your machine, you're ready to build, test, and launch your own sovere
 
 ### 🟢 Building and running wordle chain {#build-and-run-wordle-chain}
 
-We have a handy `init.sh` [found in this repo](https://github.com/rollkit/docs/blob/main/public/wordle/init.sh).
 
-We can copy it over to our directory with the following commands:
+Now let's initialize a `rollkit.toml` file in the `worldle` directory by running:
+
+```bash
+rollkit toml init
+```
+
+To start running a rollup with the Wordle chain, run the following command:
+
+```bash
+rollkit start --rollkit.aggregator --rollkit.da_address http://localhost:7980
+```
+
+With that, we have kickstarted our wordle network!
+
+In another window, from the `~/wordle` directory  (where rollkit.toml is located)  run the following command to submit a Wordle:
 
 <!-- markdownlint-disable MD013 -->
 ```bash
-# From inside the `wordle` directory
-wget https://rollkit.dev/wordle/init.sh
-```
-<!-- markdownlint-enable MD013 -->
-
-This copies over our `init.sh` script to initialize our
-Wordle Rollup.
-
-You can view the contents of the script to see how we
-initialize the Wordle Rollup.
-
-You can initialize the script with the following command:
-
-```bash
-bash init.sh
-```
-
-With that, we have kickstarted our `wordled` network!
-
-In another window, run the following to submit a Wordle:
-
-<!-- markdownlint-disable MD013 -->
-```bash
-wordled tx wordle submit-wordle giant --from wordle-key --keyring-backend test --chain-id wordle -b async -y
+rollkit tx wordle submit-wordle giant --from wordle-key --keyring-backend test --chain-id wordle -b async -y
 ```
 <!-- markdownlint-enable MD013 -->
 
@@ -669,7 +668,7 @@ the block yet or if there are any errors.
 
 <!-- markdownlint-disable MD013 -->
 ```bash
-wordled query tx --type=hash F159E11116EC9505FC2C0D97E605357FEC0F3DAE06B57BFB17EA6A548905043E --chain-id wordle --output json | jq -r '.raw_log'
+rollkit query tx --type=hash F159E11116EC9505FC2C0D97E605357FEC0F3DAE06B57BFB17EA6A548905043E --chain-id wordle --output json | jq -r '.raw_log'
 ```
 <!-- markdownlint-enable MD013 -->
 
@@ -684,7 +683,7 @@ Test out a few things for fun:
 
 <!-- markdownlint-disable MD013 -->
 ```bash
-wordled tx wordle submit-guess 12345 --from wordle-key --keyring-backend test --chain-id wordle -b async -y
+rollkit tx wordle submit-guess 12345 --from wordle-key --keyring-backend test --chain-id wordle -b async -y
 ```
 <!-- markdownlint-enable MD013 -->
 
@@ -696,7 +695,7 @@ Now try:
 
 <!-- markdownlint-disable MD013 -->
 ```bash
-wordled tx wordle submit-guess ABCDEFG --from wordle-key --keyring-backend test --chain-id wordle -b async -y
+rollkit  tx wordle submit-guess ABCDEFG --from wordle-key --keyring-backend test --chain-id wordle -b async -y
 ```
 <!-- markdownlint-enable MD013 -->
 
@@ -708,7 +707,7 @@ Now try to submit another wordle even though one was already submitted
 
 <!-- markdownlint-disable MD013 -->
 ```bash
-wordled tx wordle submit-wordle meter --from wordle-key --keyring-backend test --chain-id wordle -b async -y
+rollkit tx wordle submit-wordle meter --from wordle-key --keyring-backend test --chain-id wordle -b async -y
 ```
 <!-- markdownlint-enable MD013 -->
 
@@ -720,7 +719,7 @@ Now let’s try to guess a five letter word:
 
 <!-- markdownlint-disable MD013 -->
 ```bash
-wordled tx wordle submit-guess least --from wordle-key --keyring-backend test --chain-id wordle -b async -y
+rollkit tx wordle submit-guess least --from wordle-key --keyring-backend test --chain-id wordle -b async -y
 ```
 <!-- markdownlint-enable MD013 -->
 
@@ -731,7 +730,7 @@ word, it will increment the guess count for wordle-key's account.
 We can verify this by querying the list:
 
 ```bash
-wordled q wordle list-guess --output json
+rollkit q wordle list-guess --output json
 ```
 
 This outputs all Guess objects submitted so far, with the index


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new guides on connecting to local DA, creating rollup genesis, configuring DA block sync time, setting max pending blocks, and using Rollkit CLI.

- **Documentation**
  - Updated sidebar navigation with renamed and reordered guide topics.
  - Refined tutorials for Celestia DA and GM world rollup with updated dependencies and commands.
  - Enhanced Wordle tutorial with new Rollkit setup instructions.

- **Chores**
  - Updated `igniteVersionTag` to `v28.4.0`.
  - Modified installation script branch in `install-gm-rollup.sh`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->