### PR TITLE
Revert "ci: update preview trigger to pull_request_target to enable previews for forks"

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,7 +1,7 @@
 name: Deploy PR previews
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,6 +1,8 @@
 name: Deploy PR previews
 
 on:
+  # This workflow requires pull_request and won't work with pull_request_target 
+  # due to github permissions 
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Reverts rollkit/docs#393

Added comment for future reference. 
You can also see that the CI now passes again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Modified the workflow trigger event from `pull_request_target` to `pull_request` to improve the timing of workflow executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->