### PR TITLE
feat: mention --rollkit.da_block_time as a tip in celestia and avail tuts

### DIFF
--- a/tutorials/avail-da.md
+++ b/tutorials/avail-da.md
@@ -70,6 +70,10 @@ Now we're prepared to initiate our rollup and establish a connection with the Av
 - `--rollkit.da_start_height`
 - `--rollkit.da_address`
 
+::: tip
+Optionally, you could also set the `--rollkit.da_block_time` flag. This should be set to the finality time of the DA layer, not its actual block time, as Rollkit does not handle reorganization logic. The default value is 15 seconds.
+:::
+
 Let's determine what to provide for each of them.
 
 First, let's query the DA Layer start height using an RPC endpoint provided by Avail Labs. For local, it would be - [https://localhost:8000/v1/latest_block]( https://localhost:8000/v1/latest_block ), and for Turing Testnet - [https://avail-turing-rpc.publicnode.com]( https://avail-turing-rpc.publicnode.com )

--- a/tutorials/celestia-da.md
+++ b/tutorials/celestia-da.md
@@ -83,6 +83,10 @@ Now we're prepared to initiate our rollup and establish a connection with the Ce
 - `--rollkit.da_auth_token`
 - `--rollkit.da_namespace`
 
+::: tip
+Optionally, you could also set the `--rollkit.da_block_time` flag. This should be set to the finality time of the DA layer, not its actual block time, as Rollkit does not handle reorganization logic. The default value is 15 seconds.
+:::
+
 Let's determine what to provide for each of them.
 
 First, let's query the DA Layer start height using an RPC endpoint provided by Celestia Labs. For Mocha testnet it would be - [https://rpc-mocha.pops.one/block](https://rpc-mocha.pops.one/block), and for mainnet beta - [https://rpc.lunaroasis.net/block](https://rpc.lunaroasis.net/block)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the `--rollkit.da_block_time` flag to specify the finality time of the DA layer, with a default value of 15 seconds.

- **Documentation**
  - Updated `avail-da.md` and `celestia-da.md` tutorials to include guidance on the `--rollkit.da_block_time` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->