### PR TITLE
chore: bump gm version

### DIFF
--- a/tutorials/gm-world.md
+++ b/tutorials/gm-world.md
@@ -46,7 +46,7 @@ To see the engine version (provided it is running): kurtosis engine status
 Now that we have kurtosis installed, we can launch our GM rollup along with the local DA by running the following command:
 
 ```bash
-kurtosis run github.com/rollkit/gm@v0.3.0
+kurtosis run github.com/rollkit/gm@v0.3.1
 ```
 
 You should see an output like this:


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Pending https://github.com/rollkit/gm/pull/112 and following release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the tutorial to reflect the new version `v0.3.1` of `github.com/rollkit/gm` in the command for launching the GM rollup alongside the local DA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->