### PR TITLE
Use rollkit cli for use-tia-for-gas how-to

### DIFF
--- a/guides/use-tia-for-gas.md
+++ b/guides/use-tia-for-gas.md
@@ -43,6 +43,22 @@ Rollkit uses the [Go programming language](https://go.dev/dl/). Here's how to in
 - **Windows**: Download and execute the <a :href="`https://go.dev/dl/go${constants.golangVersion}.windows-amd64.msi`">installer</a>.
 <!-- markdownlint-enable MD033 -->
 
+## 📦 Install Rollkit (CLI) {#install-rollkit}
+
+To install Rollkit, run the following command in your terminal:
+
+```bash-vue
+curl -sSL https://rollkit.dev/install.sh | sh -s {{constants.rollkitLatestTag}}
+```
+
+Verify the installation by checking the Rollkit version:
+
+```bash
+rollkit version
+```
+
+A successful installation will display the version number and its associated git commit hash.
+
 ## 🌐 Running a Local DA Network {#running-local-da}
 
 Learn to run a local DA network, designed for educational purposes, on your machine.
@@ -71,7 +87,22 @@ If you get errors of `gmd` not found, you may need to add the `go/bin` directory
 :::
 
 ```bash
-(cd /tmp && bash -c "$(curl -sSL https://rollkit.dev/install-gm-rollup.sh)")
+curl -sSL https://rollkit.dev/install-gm-rollup.sh | sh
+```
+
+## Initialize rollkit toml configuration {#initialize-rollkit-configuration}
+
+```bash
+cd ./gm && rollkit toml init
+```
+
+Edit the `rollkit.toml` file to include the following configuration:
+
+```toml
+entrypoint = "/root/gm/cmd/gmd/main.go"
+
+[chain]
+  config_dir = "./.gm"
 ```
 
 ## 🚀 Starting your rollup {#start-your-rollup}
@@ -79,7 +110,7 @@ If you get errors of `gmd` not found, you may need to add the `go/bin` directory
 Start the rollup, posting to the local DA network:
 
 ```bash
-gmd start --rollkit.aggregator --rollkit.da_address http://localhost:7980 --minimum-gas-prices="0.02ibc/C3E53D20BC7A4CC993B17C7971F8ECD06A433C10B6A96F4C4C3714F0624C56DA,0.025stake"
+rollkit start --rollkit.aggregator --rollkit.da_address http://localhost:7980 --minimum-gas-prices="0.02ibc/C3E53D20BC7A4CC993B17C7971F8ECD06A433C10B6A96F4C4C3714F0624C56DA,0.025stake"
 ```
 
 Note that we specified the gas token to be IBC TIA. We still haven't made an IBC connection to Celestia's Mocha testnet, however, if we assume our first channel will be an ICS-20 transfer channel to Celestia, we can already calculate the token denom using this formula:
@@ -223,7 +254,7 @@ Note: These accounts should always be the same because of the hardcoded mnemonic
 Fund the relayer on our rollup:
 
 ```bash
-gmd tx bank send gm-key-2 gm1jqevcsld0dqpjp3csfg7alkv3lehvn8uswknrc 10000000stake --keyring-backend test --chain-id gm --fees 5000stake -y
+rollkit tx bank send gm-key-2 gm1jqevcsld0dqpjp3csfg7alkv3lehvn8uswknrc 10000000stake --keyring-backend test --chain-id gm --fees 5000stake -y
 ```
 
 Fund the relayer on the Celestia Mocha testnet:
@@ -296,7 +327,7 @@ ACCOUNT_ON_ROLLUP="$(gmd keys show -a --keyring-backend test gm-key-2)"
 TX_HASH=$(gmd tx bank send "$ACCOUNT_ON_ROLLUP" "$ACCOUNT_ON_ROLLUP" 1stake --keyring-backend test --chain-id gm --gas-prices 0.02ibc/C3E53D20BC7A4CC993B17C7971F8ECD06A433C10B6A96F4C4C3714F0624C56DA -y --output json | jq -r .txhash)
 
 # Verify success
-gmd q tx "$TX_HASH" --output json | jq .code # => 0
+rollkit q tx "$TX_HASH" --output json | jq .code # => 0
 ```
 
 ## 🎉 Next steps

--- a/guides/use-tia-for-gas.md
+++ b/guides/use-tia-for-gas.md
@@ -90,7 +90,9 @@ If you get errors of `gmd` not found, you may need to add the `go/bin` directory
 curl -sSL https://rollkit.dev/install-gm-rollup.sh | sh
 ```
 
-## Initialize rollkit toml configuration {#initialize-rollkit-configuration}
+## 🛠️ Initialize Rollkit TOML Configuration {#initialize-rollkit-configuration}
+
+Change to the `gm` directory and initialize the rollkit toml configuration:
 
 ```bash
 cd ./gm && rollkit toml init


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Updated installation instructions for Rollkit, transitioning from `gmd` to `rollkit` commands.
  - Added a new section for installation verification and checking Rollkit version.
  - Introduced guidance on initializing the Rollkit configuration with `rollkit.toml`.
  - Standardized command examples to improve clarity and usability throughout the guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->