### PR TITLE
Add lazy_buffer_time option to the lazy_sequencing guide

### DIFF
--- a/guides/lazy-sequencing.md
+++ b/guides/lazy-sequencing.md
@@ -1,22 +1,25 @@
-# How to use lazy sequencing (aggregation)
+# How to Use Lazy Sequencing (Aggregation)
 
 In this guide, we'll go over how to use lazy sequencing.
 
-This feature was introduced in Rollkit v0.7.0 and allows rollup
-operators to wait for transactions to build blocks. This prevents
-the rollup from building empty blocks.
+This feature was introduced in Rollkit v0.7.0 (with custom buffer time later in v0.13.7) and allows rollup operators to wait for transactions before building blocks. This prevents the rollup from building empty blocks.
 
-To turn on lazy sequencing, add the following flag to your start
-command:
+To turn on lazy sequencing, add the following flag to your start command:
 
 ```bash
 --rollkit.lazy_aggregator
 ```
 
-An example command would look like this:
+Optionally, if you want to specify a custom time to wait to accumulate transactions in lazy mode, use:
+
+```bash
+--rollkit.lazy_buffer_time <duration>
+```
+
+An example command with a custom buffer wait time would look like this:
 
 ```bash
 # start the chain
 gmd start [existing flags...] // [!code --]
-gmd start [existing flags...] --rollkit.lazy_aggregator // [!code ++]
+gmd start [existing flags...] --rollkit.lazy_aggregator --rollkit.lazy_buffer_time=30s // [!code ++]
 ```


### PR DESCRIPTION
Blocked by https://github.com/rollkit/rollkit/pull/1797

Expects to have v0.13.7 released before merging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the lazy sequencing guide for improved clarity and functionality details.
	- Introduced a custom buffer time feature for rollup operators, enhancing control over transaction accumulation.
	- Added a new command option for specifying custom buffer time, with examples for user implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->