### PR TITLE
Add ignite chain build to celestia da tutorial

### DIFF
--- a/tutorials/celestia-da.md
+++ b/tutorials/celestia-da.md
@@ -49,6 +49,12 @@ Add the Rollkit app:
 ignite rollkit add
 ```
 
+Build the rollup node binary to use it for the chain configuration and to initialize:
+
+```bash
+ignite chain build
+```
+
 Initialize the Rollkit chain configuration:
 
 ```bash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added instructions for building the rollup node binary in the Rollkit chain tutorial.
	- Included the command `ignite chain build` to enhance the documentation and improve the tutorial flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->