### PR TITLE
docs: Add tip to link to Docker host network mode

### DIFF
--- a/tutorials/artela-evm-plus-plus.md
+++ b/tutorials/artela-evm-plus-plus.md
@@ -23,6 +23,10 @@ cd artela-rollkit
 
 Ensure Docker is installed on your system before setting up the Artela rollup node. If not already installed, download and follow the setup instructions available [here](https://www.docker.com/products/docker-desktop/).
 
+:::tip
+Make sure you meet these [prerequisites](https://docs.docker.com/engine/network/tutorials/host/#prerequisites) of enabling host network mode in Docker.
+:::
+
 After installing Docker, run the following command to start a local development node:
 
 ```bash


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The docker setup in Artela EVM++ tutorial uses host network mode which has some prerequisites of a docker version and instructions. This PR links those instructions as a tip.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added an informational tip regarding prerequisites for enabling host network mode in Docker to assist users in setting up the Artela rollup node successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->