### PR TITLE
chore: pdate dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,11 @@ updates:
       patch-updates:
         applies-to: version-updates
         update-types:
-          - "minor"
+          - "patch"
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     labels:
       - T:dependencies
@@ -25,4 +25,4 @@ updates:
       patch-updates:
         applies-to: version-updates
         update-types:
-          - "minor"
+          - "patch"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Grouping was mistakenly set to minor instead of patch.
Additionally moving npm trigger to weekly. Our repos use daily triggers to catch updates from our internal repos, and we don't have any npm repos. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted update configurations for package ecosystems to prioritize patch updates over minor updates.
	- Changed the update schedule for the npm package ecosystem from daily to weekly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->