### PR TITLE
test(ci): add build workflow to catch build errors in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build VitePress Site
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn # or pnpm / npm
+      - name: Install dependencies
+        run: yarn install # or pnpm install / npm ci
+      - name: Build with VitePress
+        run: yarn docs:build # or pnpm docs:build / npm docs:build

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy](https://github.com/rollkit/docs/actions/workflows/deploy.yml/badge.svg)](https://github.com/rollkit/docs/actions/workflows/deploy.yml)
+
 # Rollkit Documentation Site
 
 Welcome to the official documentation repository for Rollkit.

--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
   },
   "dependencies": {
     "node-fetch": "^3.3.2"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Something broke the docs build but it was missed because we don't have an explicit CI to verify the build. 
It was previously implicitly handled via the pr preview, but that workflow fails on forks so when the build broke on a fork, the CI failure was ignored. 

This PR as a specific build CI that can always run so that we can make it required to merge. 

TODO: 
- [ ] Fix build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new automated build workflow for the VitePress site, enhancing continuous integration.
	- The workflow triggers on code pushes and pull requests, ensuring the documentation is built automatically.
	- Updated project configuration to support ECMAScript modules, improving module management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->