### PR TITLE
docs(learn): add link to rollkit godocs along since the specifications

### DIFF
--- a/learn/specifications.md
+++ b/learn/specifications.md
@@ -2,3 +2,4 @@
 
 [Rollkit specifications](https://rollkit.github.io/rollkit/index.html) - is comprehensive documentation on the inner components of Rollkit, including data storage, transaction processing, and more. It’s an essential resource for developers looking to understand, contribute to and leverage the full capabilities of Rollkit.
 
+Additional Rollkit documentation can be found in the [Rollkit godocs](https://pkg.go.dev/github.com/rollkit/rollkit).


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Closes #473 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new resource link to the documentation for Rollkit, enhancing developer access to information.
  
- **Documentation**
	- Updated the specifications document to include a reference to the "Rollkit godocs."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->