### PR TITLE
fix: update rollkit versions in constants.js

### DIFF
--- a/.vitepress/constants/constants.js
+++ b/.vitepress/constants/constants.js
@@ -4,8 +4,8 @@ const constants = Object.freeze({
   nodeVersion: "21.7.2",
   yarnVersion: "1.22.19",
 
-  rollkitLatestTag: "v0.13.8",
-  rollkitLatestSha: "6a33192",
+  rollkitLatestTag: "v0.13.7",
+  rollkitLatestSha: "8deede4",
   rollkitCosmosSDKVersion: "v0.50.6-rollkit-v0.13.3-no-fraud-proofs",
   rollkitIgniteAppVersion: "v0.2.1",
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

The rollkit version was somehow a version ahead. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated `rollkitLatestTag` to the correct version "v0.13.7".
	- Corrected `rollkitLatestSha` to reflect the accurate SHA "8deede4".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->