### PR TITLE
chore: clean up cometbft tutorial to remove outdate DA references

### DIFF
--- a/guides/cometbft-to-rollkit.md
+++ b/guides/cometbft-to-rollkit.md
@@ -26,11 +26,11 @@ Now that Rollkit is installed, you can add Rollkit features to your existing blo
 ignite rollkit add
 ```
 
-## Initialize Rollkit with Local DA {#initialize-rollkit-local-da}
+## Initialize Rollkit {#initialize-rollkit}
 
-To prepare your app for Rollkit, you'll need to initialize it with Local Data Availability (Local DA). This allows your app to interact with a lightweight, testable DA layer.
+To prepare your app for Rollkit, you'll need to initialize it.
 
-Run the following command to initialize Rollkit with Local DA:
+Run the following command to initialize Rollkit:
 
 ```bash
 ignite rollkit init
@@ -53,9 +53,11 @@ This command sets up the `rollkit.toml` file, where you can further customize co
 Once everything is configured, you can start your Rollkit-enabled CometBFT app or (simply rollkit app). Use the following command to start your blockchain:
 
 ```bash
-rollkit start --rollkit.aggregator --rollkit.da_address http://localhost:7980
+rollkit start --rollkit.aggregator <insert your flags>
 ```
 
 ## Summary
 
 By following this guide, you've successfully converted your CometBFT app into a Rollkit app.
+
+To learn more about how to config your DA, Sequencing, and Execution, please check out those tutorial sections.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and conciseness in the guide for converting a CometBFT app to a Rollkit app.
	- Simplified section headers and streamlined initialization instructions.
	- Updated command for starting the Rollkit app to enhance flexibility in configuration.
	- Added encouragement for users to explore additional tutorial sections related to Data Availability, Sequencing, and Execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->