### PR TITLE
feat: add go version comparison to rollkit install script

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -1,5 +1,33 @@
 #!/bin/bash
 
+# Define colors for output
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+CYAN="\033[36m"
+BOLD="\033[1m"
+RESET="\033[0m"
+
+# Function to print headers
+print_header() {
+    echo -e "${CYAN}${BOLD}--> $1${RESET}"
+}
+
+# Function to print success messages
+print_success() {
+    echo -e "${GREEN}${BOLD}$1${RESET}"
+}
+
+# Function to print warnings
+print_warning() {
+    echo -e "${YELLOW}${BOLD}$1${RESET}"
+}
+
+# Function to print errors
+print_error() {
+    echo -e "${RED}${BOLD}$1${RESET}"
+}
+
 # Function to compare versions
 compare_versions() {
     if [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$1" ]; then
@@ -13,56 +41,55 @@ compare_versions() {
     fi
 }
 
-# Step 1: Download Rollkit source code
-echo "Downloading Rollkit source code..."
+print_header "Downloading Rollkit source code..."
 git clone https://github.com/rollkit/rollkit.git
+echo ""
 
-# Navigate into the Rollkit repository
-cd rollkit || { echo "Failed to find the downloaded repository."; exit 1; }
+cd rollkit || { print_error "Failed to find the downloaded repository."; exit 1; }
 
-# Step 2: Extract the Go version from the go.mod file in the Rollkit repo
+print_header "Extracting Go version from go.mod..."
 go_mod_version=$(grep "^go " go.mod | cut -d' ' -f2)
 
-# Check if go.mod version was found
 if [ -z "$go_mod_version" ]; then
-    echo "Error: Could not find a Go version in go.mod."
+    print_error "Error: Could not find a Go version in go.mod."
     exit 1
 fi
-
-# Format Go version for installation (e.g., "1.22.2" -> "go1.22.2")
 formatted_go_version="go${go_mod_version}"
+echo -e "   Required Go version: ${BOLD}${formatted_go_version}${RESET}\n"
 
-# Step 3: Check if Go is installed
+print_header "Checking if Go is installed..."
 if ! which go > /dev/null; then
-    echo "Go is not installed. Attempting to install Go..."
+    print_warning "Go is not installed. Attempting to install Go..."
     curl -sL "https://rollkit.dev/install-go.sh" | sh -s "$formatted_go_version"
 fi
 
-# Get the installed Go version
 installed_version=$(go version | awk '{print $3}' | sed 's/go//')
+echo -e "   Installed Go version: ${BOLD}${installed_version}${RESET}\n"
 
-# Step 4: Validate installed version
+print_header "Validating installed Go version..."
 compare_versions "$installed_version" "$go_mod_version"
 comparison_result=$?
 
 if [ $comparison_result -eq 1 ]; then
-    echo "ERROR: The installed Go version ($installed_version) is less than the required version ($go_mod_version)."
-    echo "       Please upgrade your version of go."
+    print_error "ERROR: The installed Go version ($installed_version) is less than the required version ($go_mod_version)."
+    echo "       Please upgrade your version of Go."
     exit 1
 elif [ $comparison_result -eq 2 ]; then
-    echo "INFO: The installed Go version ($installed_version) is greater than the required version ($go_mod_version)."
-    echo "      If you run into issues try downgrading your version of go."
+    print_warning "INFO: The installed Go version ($installed_version) is greater than the required version ($go_mod_version)."
+    echo "      If you run into issues, try downgrading your version of Go."
 fi
+echo ""
 
-# Step 5: Continue with the installation of Rollkit
-echo "Fetching and checking out the specified branch or tag..."
+print_header "Fetching and checking out the specified branch or tag..."
 git fetch && git checkout "$1"
+echo ""
 
-echo "Building and installing Rollkit..."
+print_header "Building and installing Rollkit..."
 make install
+print_success "Rollkit CLI installed successfully!"
 
 cd ..
-echo "Installation completed successfully."
-echo "Cleaning up downloads..."
+print_header "Cleaning up downloads..."
 rm -rf rollkit
 
+print_success "Installation completed successfully."

--- a/public/install.sh
+++ b/public/install.sh
@@ -1,17 +1,68 @@
 #!/bin/bash
 
+# Function to compare versions
+compare_versions() {
+    if [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$1" ]; then
+        if [ "$1" = "$2" ]; then
+            return 0 # Equal
+        else
+            return 1 # First is less
+        fi
+    else
+        return 2 # First is greater
+    fi
+}
+
+# Step 1: Download Rollkit source code
 echo "Downloading Rollkit source code..."
 git clone https://github.com/rollkit/rollkit.git
 
-if ! which go > /dev/null; then
-	echo "Go is not installed. Attempting to install Go..."
-	curl -sL "https://rollkit.dev/install-go.sh" | sh -s "go1.22.2"
+# Navigate into the Rollkit repository
+cd rollkit || { echo "Failed to find the downloaded repository."; exit 1; }
+
+# Step 2: Extract the Go version from the go.mod file in the Rollkit repo
+go_mod_version=$(grep "^go " go.mod | cut -d' ' -f2)
+
+# Check if go.mod version was found
+if [ -z "$go_mod_version" ]; then
+    echo "Error: Could not find a Go version in go.mod."
+    exit 1
 fi
 
-cd rollkit || { echo "Failed to find the downloaded repository."; exit 1; }
-git fetch && git checkout $1
+# Format Go version for installation (e.g., "1.22.2" -> "go1.22.2")
+formatted_go_version="go${go_mod_version}"
+
+# Step 3: Check if Go is installed
+if ! which go > /dev/null; then
+    echo "Go is not installed. Attempting to install Go..."
+    curl -sL "https://rollkit.dev/install-go.sh" | sh -s "$formatted_go_version"
+fi
+
+# Get the installed Go version
+installed_version=$(go version | awk '{print $3}' | sed 's/go//')
+
+# Step 4: Validate installed version
+compare_versions "$installed_version" "$go_mod_version"
+comparison_result=$?
+
+if [ $comparison_result -eq 1 ]; then
+    echo "ERROR: The installed Go version ($installed_version) is less than the required version ($go_mod_version)."
+    echo "       Please upgrade your version of go."
+    exit 1
+elif [ $comparison_result -eq 2 ]; then
+    echo "INFO: The installed Go version ($installed_version) is greater than the required version ($go_mod_version)."
+    echo "      If you run into issues try downgrading your version of go."
+fi
+
+# Step 5: Continue with the installation of Rollkit
+echo "Fetching and checking out the specified branch or tag..."
+git fetch && git checkout "$1"
+
 echo "Building and installing Rollkit..."
 make install
+
 cd ..
 echo "Installation completed successfully."
+echo "Cleaning up downloads..."
+rm -rf rollkit
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

This resolves the underlying issue from #523 where the user's go version was lower than the required version. 

The script now explicitly checks the go version in the go.mod of rollkit and compares against the local version. 

Example output now
<img width="596" alt="Screenshot 2024-12-04 at 9 17 04 AM" src="https://github.com/user-attachments/assets/3526bd5b-61c9-4967-bd51-a888e3acc4a8">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced installation script with improved user feedback and error handling.
	- Introduced color-coded messages for different severity levels during installation.
	- Dynamic retrieval of required Go version from `go.mod` for better version management.
	- Added validation for installed Go version with detailed comparison messages.

- **Bug Fixes**
	- Improved error handling for Go version extraction and installation checks. 

- **Documentation**
	- Updated user notifications to provide clearer information during the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->