### PR TITLE
Fix: Broken Links in Documentation Files

### DIFF
--- a/guides/block-times.md
+++ b/guides/block-times.md
@@ -1,7 +1,7 @@
 # How to change speed of block production
 
 If you have gone through both the [quick start tutorial](../tutorials/quick-start.md) and the
-[Full and sequencer node rollup setup](./full-and-sequencer-node)
+[Full and sequencer node rollup setup](./full-node)
 already, you're now ready to experiment with faster block times.
 
 In your `rollkit start [args...]` command, you will need to add a flag

--- a/guides/cw-orch.md
+++ b/guides/cw-orch.md
@@ -245,7 +245,7 @@ Now that you workspace is setup, you can [integrate with single contracts](#sing
 
 You can find more example interactions on the `counter-contract` example directly in the `cw-orchestrator` repo:  
 
-- Some examples <a href="https://github.com/AbstractSDK/cw-orchestrator/blob/main/contracts/counter/examples/deploy.rs" target="_blank">showcase interacting with live chains</a>.
-- Some other examples show <a href="https://github.com/AbstractSDK/cw-orchestrator/tree/main/contracts/counter/tests" target="_blank">how to use the library for testing your contracts</a>.
+- Some examples <a href="https://github.com/AbstractSDK/cw-orchestrator/blob/main/contracts-ws/contracts/counter/examples/deploy.rs" target="_blank">showcase interacting with live chains</a>.
+- Some other examples show <a href="https://github.com/AbstractSDK/cw-orchestrator/tree/main/contracts-ws/contracts/counter/tests" target="_blank">how to use the library for testing your contracts</a>.
 
 > **FINAL ADVICE**: Learn more and explore our <a href="https://orchestrator.abstract.money" target="blank" >full `cw-orch` documentation !</a>.

--- a/guides/ibc-connection.md
+++ b/guides/ibc-connection.md
@@ -1,7 +1,7 @@
 # IBC connection tutorial
 
 In this tutorial, we'll learn how to use [an Inter-Blockchain Communication (IBC) Protocol relayer](https://github.com/cosmos/relayer) to
-create an IBC connection between a [GM world](./gm-world) rollup and an Osmosis local testnet.
+create an IBC connection between a [GM world](../tutorials/gm-world) rollup and an Osmosis local testnet.
 
 :::warning Disclaimer
 This initial version of IBC has high trust assumptions where receiving chains


### PR DESCRIPTION
This pull request fixes broken links in the documentation files. Specifically, it addresses issues with links in the following files:
- `full-node block-times.md`
- `cw-orch.md`
- `ibc-connection.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated link references in multiple guides:
    - Block times guide: Updated link to full node setup
    - CosmWasm orchestrator guide: Updated example file paths
    - IBC connection guide: Corrected link to GM world rollup tutorial

<!-- end of auto-generated comment: release notes by coderabbit.ai -->