### PR TITLE
docs: Fix incorrect verb form in Block manager section Update stack.md

### DIFF
--- a/learn/stack.md
+++ b/learn/stack.md
@@ -62,7 +62,7 @@ The [mempool](https://github.com/rollkit/rollkit/tree/main/mempool) is inspired 
 
 ### Block manager
 
-The [block manager](https://github.com/rollkit/rollkit/tree/main/block) contains routines `AggregationLoop`, `RetrieveLoop`, and `SyncLoop` that communicate through Go channels. These Go routines are ran when a Rollkit node starts up (`OnStart`). Only the sequencer nodes run `AggregationLoop` which controls the frequency of block production for a rollup with a timer as per the `BlockTime` in `BlockManager`.
+The [block manager](https://github.com/rollkit/rollkit/tree/main/block) contains routines `AggregationLoop`, `RetrieveLoop`, and `SyncLoop` that communicate through Go channels. These Go routines are run when a Rollkit node starts up (`OnStart`). Only the sequencer nodes run `AggregationLoop` which controls the frequency of block production for a rollup with a timer as per the `BlockTime` in `BlockManager`.
 
 All nodes run `SyncLoop` which looks for the following operations:
 


### PR DESCRIPTION
## Overview

I noticed a typo in the Node components section, under Block manager.
The sentence "These Go routines are ran when a Rollkit node starts up (OnStart)" uses the incorrect verb form.
It should be "**run**" instead of "ran." 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Rollkit documentation to correct grammatical tense in description of block manager routines, replacing "ran" with "run"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->