### PR TITLE
docs: Fix typos and improve clarity in documentation in reset-state.md

### DIFF
--- a/guides/reset-state.md
+++ b/guides/reset-state.md
@@ -3,7 +3,7 @@
 This guide will walk you through how you reset the state of your chain.
 
 :::warning Disclaimer
-By definition, reseting the state is deleting your chain's data. Make sure you understand the implications of this prior to completion this guide.
+By definition, resetting the state is deleting your chain's data. Make sure you understand the implications of this prior to completing this guide.
 :::
 
 Some reason you might need to reset the state of your chain are:
@@ -11,7 +11,7 @@ Some reason you might need to reset the state of your chain are:
 * During upgrades with breaking changes
 * Hardforks
 
-## Prerequisities 
+## Prerequisites 
 
 In order to complete this guide, you will need to have completed either the [quick start tutorial](/tutorials/quick-start.md) or the [build our chain tutorial](/tutorials/wordle.md).
 
@@ -51,7 +51,7 @@ When you launch your chain again with `rollkit start` your `.rollkit` directory 
 
 ## Wordle
 
-When you ran your wordle chain in the [build your chain turtorial](/tutorials/wordle.md), it created a `.wordle` directory.
+When you ran your wordle chain in the [build your chain tutorial](/tutorials/wordle.md), it created a `.wordle` directory.
 
 This directory will look like the following:
 


### PR DESCRIPTION
## Overview

I noticed a few typos and inaccuracies in the documentation that could cause confusion. Here are the fixes:  
- Corrected "reseting" to "resetting" in the sentence about resetting the state.  
- Fixed "completion" to "completing" in the guide instructions.  
- Updated "Prerequisities" to "Prerequisites" in the heading.  
- Changed "turtorial" to "tutorial" in the Wordle chain explanation.  

These changes ensure the documentation is accurate and easier to understand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed spelling and grammar errors in the guide
  - Corrected section headers and terminology
  - Improved overall document clarity and readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->